### PR TITLE
Gets the maximum and minimum slice numbers from the extent instead of the image dimensions

### DIFF
--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -116,14 +116,14 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
             advance = 10
 
         if event == 'MouseWheelForwardEvent':
-            maxSlice = self.GetDimensions()[self.GetSliceOrientation()]
+            maxSlice = self._viewer.img3D.GetExtent()[self.GetSliceOrientation()*2+1]
             # print (self.GetActiveSlice())
-            if (self.GetActiveSlice() + advance < maxSlice):
+            if (self.GetActiveSlice() + advance <= maxSlice):
                 self.SetActiveSlice(self.GetActiveSlice() + advance)
                 self.UpdatePipeline()
         else:
-            minSlice = 0
-            if (self.GetActiveSlice() - advance > minSlice):
+            minSlice = self._viewer.img3D.GetExtent()[self.GetSliceOrientation()*2]
+            if (self.GetActiveSlice() - advance >= minSlice):
                 self.SetActiveSlice(self.GetActiveSlice() - advance)
                 self.UpdatePipeline()
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -110,16 +110,21 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         self._viewer.showActor(actorno)
 
     def mouseInteraction(self, interactor, event):
+        shift = interactor.GetShiftKey()
+        advance = 1
+        if shift:
+            advance = 10
+
         if event == 'MouseWheelForwardEvent':
             maxSlice = self.GetDimensions()[self.GetSliceOrientation()]
             # print (self.GetActiveSlice())
-            if (self.GetActiveSlice() + 1 < maxSlice):
-                self.SetActiveSlice(self.GetActiveSlice() + 1)
+            if (self.GetActiveSlice() + advance < maxSlice):
+                self.SetActiveSlice(self.GetActiveSlice() + advance)
                 self.UpdatePipeline()
         else:
             minSlice = 0
-            if (self.GetActiveSlice() - 1 > minSlice):
-                self.SetActiveSlice(self.GetActiveSlice() -1)
+            if (self.GetActiveSlice() - advance > minSlice):
+                self.SetActiveSlice(self.GetActiveSlice() - advance)
                 self.UpdatePipeline()
 
     def OnLeftMouseClick(self, interactor, event):

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -170,7 +170,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         elif interactor.GetKeyCode() == "y":
 
             self.SetSliceOrientation(SLICE_ORIENTATION_XZ)
-            self.SetActiveSlice(int(self.GetDimensions()[2] / 2))
+            self.SetActiveSlice(int(self.GetDimensions()[1] / 2))
             self.UpdatePipeline(resetcamera=True)
 
         elif interactor.GetKeyCode() == "z":

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -369,13 +369,13 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
 
     ############### Handle events
     def OnMouseWheelForward(self, interactor, event):
-        maxSlice = self.GetDimensions()[self.GetSliceOrientation()]
+        maxSlice = self.GetInputData().GetExtent()[self.GetSliceOrientation()*2+1]
         shift = interactor.GetShiftKey()
         advance = 1
         if shift:
             advance = 10
 
-        if (self.GetActiveSlice() + advance < maxSlice):
+        if (self.GetActiveSlice() + advance <= maxSlice):
             self.SetActiveSlice(self.GetActiveSlice() + advance)
 
             self.UpdatePipeline()
@@ -386,7 +386,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
             self.DisplayLineProfile(interactor, event, True)
 
     def OnMouseWheelBackward(self, interactor, event):
-        minSlice = 0
+        minSlice = self.GetInputData().GetExtent()[self.GetSliceOrientation()*2]
         shift = interactor.GetShiftKey()
         advance = 1
         if shift:

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -142,6 +142,15 @@ class ViewerLinker():
 
         self._to.linkSlice = linkSlice
         self._from.linkSlice = linkSlice
+    
+    def setLinkOrientation(self, linkOrientation):
+        """
+        Boolean flag to set slice orientation linkage
+        :param linkOrientation: (boolean)
+        """
+
+        self._to.linkOrientation = linkOrientation
+        self._from.linkOrientation = linkOrientation
 
 
 #################################
@@ -182,6 +191,7 @@ class ViewerLinkObserver():
         self.linkPick = True
         self.linkWindowLevel = True
         self.linkSlice = True
+        self.linkOrientation = True
 
     def __call__(self, interactor, event):
         """
@@ -304,11 +314,10 @@ class ViewerLinkObserver():
                         self.targetVtkViewer.GetSliceOrientation()):
                     shouldPassEvent = False
 
-        # KeyPress
-        if (event == "KeyPressEvent" or
-                state == 1026):
-
-            shouldPassEvent = False
+        # KeyPress and orientation
+        if (event == "KeyPressEvent"  or state == 1026):
+                if ( not (self.linkOrientation and ( interactor.GetKeyCode() == "x" or interactor.GetKeyCode() == "y" or interactor.GetKeyCode() == "z"))):
+                    shouldPassEvent = False
             
         # Check if event should be passed
         if (shouldPassEvent):


### PR DESCRIPTION
The dimensions of an image may be different to the extent and this is important when slicing the image. The first image slice may not appear at coordinate 0 - we need to define the minimum slice as the lowest bound of the extent.