### PR TITLE
Add github action for building and publishing to conda

### DIFF
--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -9,14 +9,14 @@ on:
     branches: [ main ]
     
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
       uses: paskino/conda-package-publish-action@master
       with:
-        subDir: 'conda'
+        subDir: 'Wrappers/python/conda-recipe'
         channels: 'conda-forge'
         AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
         publish: ${{ github.event_name == 'release'}}

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -17,6 +17,6 @@ jobs:
       uses: paskino/conda-package-publish-action@master
       with:
         subDir: 'Wrappers/Python/conda-recipe'
-        channels: 'conda-forge'
+        channels: 'conda-forge -c paskino'
         AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
         publish: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -19,4 +19,4 @@ jobs:
         subDir: 'Wrappers/python/conda-recipe'
         channels: 'conda-forge'
         AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
-        publish: ${{ github.event_name == 'release'}}
+        publish: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -1,0 +1,22 @@
+name: publish_conda
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: publish-to-conda
+      uses: paskino/conda-package-publish-action@master
+      with:
+        subDir: 'conda'
+        channels: 'conda-forge'
+        AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
+        publish: ${{ github.event_name == 'release'}}

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -4,9 +4,9 @@ on:
   release:
     types: [published]
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
     
 jobs:
   build:

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: publish-to-conda
       uses: paskino/conda-package-publish-action@master
       with:
-        subDir: 'Wrappers/python/conda-recipe'
+        subDir: 'Wrappers/Python/conda-recipe'
         channels: 'conda-forge'
         AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
         publish: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}


### PR DESCRIPTION
I added the secret ANACONDA_TOKEN. This has the same value as on Jenkins.