### PR TITLE
create version from repo tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ccpi_viewer.egg-info
 *.pyc
 __pycache__
 
+Wrappers/Python/ccpi/viewer/version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v***
+* infer the version string from the repository tag
 * fix bug with orientation axes when the input image is updated
 * Allow colormap to be changed in the 3D viewer to any colormap available in matplotlib
 

--- a/Wrappers/Python/ccpi/viewer/__init__.py
+++ b/Wrappers/Python/ccpi/viewer/__init__.py
@@ -2,5 +2,6 @@ from .CILViewer import CILViewer as viewer3D
 from .CILViewer2D import CILViewer2D as viewer2D
 from .CILViewer import CILInteractorStyle as istyle3D
 from .CILViewer2D import CILInteractorStyle as istyle2D
+from .version import dversion
 
-__version__ = "21.1.0"
+__version__ = dversion

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -1,11 +1,15 @@
 package:
   name: ccpi-viewer
-  version: 21.0.1
+  version: {{ environ.get('GIT_DESCRIBE_TAG','v')[1:] }}
 
+source:
+  path: ../../../
 
 build:
-  preserve_egg_dir: False
-  number: 0
+  skip: True # [py==38 and np==115]
+  preserve_egg_dir: False 
+  number: {{ GIT_DESCRIBE_NUMBER }}
+
   
 requirements:
   build:

--- a/Wrappers/Python/setup.py
+++ b/Wrappers/Python/setup.py
@@ -16,12 +16,26 @@
 from distutils.core import setup
 import os
 import sys
+import subprocess
 
-cil_version = "21.0.0"
-if os.environ.get('CONDA_BUILD', None) is not None:
+
+cil_version = subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()
+
+
+if os.environ.get('CONDA_BUILD', 0) == 0:
+    cwd = os.getcwd()
     requires = []
 else:
     requires = ['numpy','vtk']
+    cwd = os.path.join(os.environ.get('RECIPE_DIR'),'..')
+
+fname = os.path.join(cwd, 'ccpi', 'viewer', 'version.py')
+
+if os.path.exists(fname):
+    os.remove(fname)
+with open(fname, 'w') as f:
+    f.write('version = \'{}\''.format(cil_version))
+    
 
 setup(
     name="ccpi-viewer",


### PR DESCRIPTION
Infers the version from repository tag. 
Adds a way to get the version string programmatically by 
```python

from ccpi.viewer import version as vversion

print (vversion.version)

>>> v20.04-80-geaa5247
```