### PR TITLE
fixed window level and event key w

### DIFF
--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -46,13 +46,14 @@ class ViewerEventManager(object):
     def __init__(self):
         # If all values are false it signifies no event
         self.events = {
-            "PICK_EVENT": False,                # left  mouse
-            "WINDOW_LEVEL_EVENT": False,        # alt + right mouse + move
-            "ZOOM_EVENT": False,                # shift + right mouse + move
-            "PAN_EVENT": False,                 # ctrl + right mouse + move
-            "CREATE_ROI_EVENT": False,          # ctrl + left mouse
-            "DELETE_ROI_EVENT": False,          # alt + left mouse
-            "SHOW_LINE_PROFILE_EVENT": False    # l
+            "PICK_EVENT": False,                       # left  mouse
+            "WINDOW_LEVEL_EVENT": False,               # alt + right mouse + move
+            "ZOOM_EVENT": False,                       # shift + right mouse + move
+            "PAN_EVENT": False,                        # ctrl + right mouse + move
+            "CREATE_ROI_EVENT": False,                 # ctrl + left mouse
+            "DELETE_ROI_EVENT": False,                 # alt + left mouse
+            "SHOW_LINE_PROFILE_EVENT": False,          # l
+            "UPDATE_WINDOW_LEVEL_UNDER_CURSOR": False  # Mouse move + w
         }
 
     def __str__(self):
@@ -87,6 +88,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
         self.AddObserver("MouseWheelForwardEvent" , self.OnMouseWheelForward , priority)
         self.AddObserver("MouseWheelBackwardEvent" , self.OnMouseWheelBackward, priority)
         self.AddObserver('KeyPressEvent', self.OnKeyPress, priority)
+        self.AddObserver('KeyReleaseEvent', self.OnKeyRelease, priority)
         self.AddObserver('LeftButtonPressEvent',
                          self.OnLeftButtonPressEvent,
                          priority)
@@ -500,11 +502,10 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
             # reset color/window
             cmin, cmax = self._viewer.ia.GetAutoRange()
 
-            # probably the level could be the median of the image within
-            # the percintiles
-            level = self._viewer.ia.GetMedian()
+            # set the level to the average value between the percintiles
+            level = (cmin + cmax) / 2
             # accommodates all values between the level an the percentiles
-            window = 2*max(abs(level-cmin),abs(level-cmax))
+            window = (cmax - cmin) / 2
 
             self.SetInitialLevel(level)
             self.SetInitialWindow(window)
@@ -539,68 +540,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
         elif interactor.GetKeyCode() == "h":
             self.DisplayHelp()
         elif interactor.GetKeyCode() == "w":
-            x,y = interactor.GetEventPosition()
-            # print (x,y)
-            ic = self.display2imageCoordinate((x,y))
-            # print (ic)
-            whole_extent = self._viewer.img3D.GetExtent()
-            around = 20
-            extent = [ ic[0]-around, ic[0]+around, 
-                       ic[1]-around, ic[1]+around, 
-                       ic[2]-around, ic[2]+around]
-            
-            
-            orientation = self._viewer.sliceOrientation
-            
-            extent[orientation * 2] = self._viewer.sliceno
-            extent[orientation * 2 + 1] = self._viewer.sliceno
-
-            if extent[0] < whole_extent[0]:
-                extent[0] = whole_extent[0]
-            if extent[1] > whole_extent[1]:
-                extent[1] = whole_extent[1]
-            if extent[2] < whole_extent[2]:
-                extent[2] = whole_extent[2]
-            if extent[3] > whole_extent[3]:
-                extent[3] = whole_extent[3]
-            if extent[4] < whole_extent[4]:
-                extent[4] = whole_extent[4]
-            if extent[5] > whole_extent[5]:
-                extent[5] = whole_extent[5]
-            # get mouse location
-            
-            self._viewer.voicursor.SetInputData(self._viewer.img3D)
-            self._viewer.voicursor.SetVOI(extent[0], extent[1],
-                       extent[2], extent[3],
-                       extent[4], extent[5])
-    
-            self._viewer.voicursor.Update()
-            # set window/level for current slices
-    
-    
-            self._viewer.iacursor.SetInputConnection(self._viewer.voicursor.GetOutputPort())
-            self._viewer.iacursor.SetAutoRangePercentiles(1.0,99.)
-            self._viewer.iacursor.Update()
-            # reset color/window
-            cmin, cmax = self._viewer.iacursor.GetAutoRange()
-
-            # probably the level could be the median of the image within
-            # the percintiles
-            level = self._viewer.iacursor.GetMedian()
-            # accommodates all values between the level an the percentiles
-            window = 2*max(abs(level-cmin),abs(level-cmax))
-
-            self.SetInitialLevel( level )
-            self.SetInitialWindow( window )
-
-            self.GetWindowLevel().SetLevel(self.GetInitialLevel())
-            self.GetWindowLevel().SetWindow(self.GetInitialWindow())
-
-            self.GetWindowLevel().Update()
-
-            self.UpdateSliceActor()
-            self.AdjustCamera()
-            self.Render()
+            self.SetEventActive('UPDATE_WINDOW_LEVEL_UNDER_CURSOR')
         elif interactor.GetKeyCode() == "t":
             # tracing event is captured by widget
             pass
@@ -608,9 +548,13 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
             # toggle interpolation of slice actor
             is_interpolated = self._viewer.sliceActor.GetInterpolate()
             self._viewer.sliceActor.SetInterpolate(not is_interpolated)
-        else :
+        else:
             self.log("Unhandled event %s" % (interactor.GetKeyCode()))
-            
+    
+    def OnKeyRelease(self, interactor, event):
+        if self.GetViewerEvent('UPDATE_WINDOW_LEVEL_UNDER_CURSOR'):
+            self.log ("remove event UPDATE_WINDOW_LEVEL_UNDER_CURSOR")
+            self.SetEventInactive('UPDATE_WINDOW_LEVEL_UNDER_CURSOR')
 
     def OnLeftButtonPressEvent(self, interactor, event):
         # print ("INTERACTOR", interactor)
@@ -952,6 +896,69 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
 
             elif self.GetViewerEvent("SHOW_LINE_PROFILE_EVENT"):
                 self.DisplayLineProfile(interactor, event, True)
+            elif self.GetViewerEvent('UPDATE_WINDOW_LEVEL_UNDER_CURSOR'):
+                print ("event w")
+                x,y = interactor.GetEventPosition()
+                # print (x,y)
+                ic = self.display2imageCoordinate((x,y))
+                print (x,y, ic, "image coordinate")
+                whole_extent = self._viewer.img3D.GetExtent()
+                around = numpy.min(numpy.asarray([whole_extent[1], whole_extent[3], whole_extent[5]])) // 10
+                print (around, "around")
+                extent = [ ic[0]-around, ic[0]+around, 
+                        ic[1]-around, ic[1]+around, 
+                        ic[2]-around, ic[2]+around]
+                
+                
+                orientation = self._viewer.sliceOrientation
+                
+                extent[orientation * 2] = self.GetActiveSlice()
+                extent[orientation * 2 + 1] = self.GetActiveSlice()
+
+                if extent[0] < whole_extent[0]:
+                    extent[0] = whole_extent[0]
+                if extent[1] > whole_extent[1]:
+                    extent[1] = whole_extent[1]
+                if extent[2] < whole_extent[2]:
+                    extent[2] = whole_extent[2]
+                if extent[3] > whole_extent[3]:
+                    extent[3] = whole_extent[3]
+                if extent[4] < whole_extent[4]:
+                    extent[4] = whole_extent[4]
+                if extent[5] > whole_extent[5]:
+                    extent[5] = whole_extent[5]
+                # get mouse location
+                
+                print (*extent, "w extent")
+                self._viewer.voicursor.SetInputData(self._viewer.img3D)
+                self._viewer.voicursor.SetVOI( *extent )
+        
+                self._viewer.voicursor.Update()
+                # set window/level for current slices
+        
+        
+                self._viewer.iacursor.SetInputConnection(self._viewer.voicursor.GetOutputPort())
+                self._viewer.iacursor.SetAutoRangePercentiles(1.0,99.)
+                self._viewer.iacursor.Update()
+                # reset color/window
+                cmin, cmax = self._viewer.iacursor.GetAutoRange()
+
+                # set the level to the average between the percentiles 
+                level = (cmin + cmax)/2
+                # accommodates all values between the level an the percentiles
+                window = (cmax - cmin) / 2
+
+                self.SetInitialLevel( level )
+                self.SetInitialWindow( window )
+
+                self.GetWindowLevel().SetLevel(self.GetInitialLevel())
+                self.GetWindowLevel().SetWindow(self.GetInitialWindow())
+
+                self.GetWindowLevel().Update()
+
+                self.UpdateSliceActor()
+                self.AdjustCamera()
+                self.Render()
 
     def DisplayHelp(self):
         help_actor = self._viewer.helpActor
@@ -1119,7 +1126,6 @@ class CILInteractorStyle(vtk.vtkInteractorStyleImage):
 
     def HandlePickEvent(self, interactor, event):
         position = interactor.GetEventPosition()
-
         vox = self.display2imageCoordinate(position)
         self.last_picked_voxel = vox
         # print ("Pixel %d,%d,%d Value %f" % vox )
@@ -1516,16 +1522,15 @@ class CILViewer2D():
 
         self.wl = vtk.vtkImageMapToWindowLevelColors()
         self.ia.SetInputData(self.voi.GetOutput())
-        self.ia.SetAutoRangePercentiles(1.0,99.)
+        self.ia.SetAutoRangePercentiles(5.0,95.)
         self.ia.Update()
         #cmax = self.ia.GetMax()[0]
         #cmin = self.ia.GetMin()[0]
         cmin, cmax = self.ia.GetAutoRange()
-        # probably the level could be the median of the image within
-        # the percentiles 
-        level = self.ia.GetMedian()
+        # set the level to the average between the percentiles 
+        level = ( cmin + cmax ) / 2
         # accomodates all values between the level an the percentiles
-        window = 2*max(abs(level-cmin),abs(level-cmax))
+        window = ( cmax - cmin ) / 2
 
         self.InitialLevel = level
         self.InitialWindow = window


### PR DESCRIPTION
Fixes the auto window level which now uses the average value between 1 and 99 percentile as level and the difference for window. Before it was the median.

Also fixes the behaviour of the event triggered by `w` in Qt, i.e. update the window level based on a smaller area of the image under the cursor. The area is 10% in each direction of the whole image extent.