### PR TITLE
Add ErrorObserver and EndObserver for handling errors in our readers

### DIFF
--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -754,11 +754,14 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
         return self.__IsAcquisitionData
 
     def ReadDataSetInfo(self):
-        '''Not implemented for Base class
-        Tries to read info about dataset from given file
+        '''Tries to read info about dataset
         Will raise specific errors if inputs required for 
         file type are not set.'''
-        pass
+        if self.__StoredArrayShape is None:
+            raise Exception("StoredArrayShape must be set.")
+        
+        if self.__OutputVTKType is None:
+            raise Exception("Typecode must be set.")
 
     def _GetInternalChunkReader(self):
         tmpdir = tempfile.mkdtemp()

--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -600,7 +600,7 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
     def __init__(self):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
 
-        self.__FileName = 1
+        self.__FileName = None
         self.__TargetSize = 256*256*256
         self.__IsFortran = False
         self.__BigEndian = False
@@ -753,6 +753,9 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
     def GetIsAcquisitionData(self):
         return self.__IsAcquisitionData
 
+    def ReadDataSetInfo(self):
+        pass
+
     def _GetInternalChunkReader(self):
         tmpdir = tempfile.mkdtemp()
         self._SetTempDir(tmpdir)
@@ -833,23 +836,27 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
         self.__TempDir = folder
 
     def RequestData(self, request, inInfo, outInfo):
-        # print("RequestData BaseResampleReader")
-        outData = vtk.vtkImageData.GetData(outInfo)
-
-        # get basic info
-        readshape = self.GetStoredArrayShape()
-        is_fortran = self.GetIsFortran()
-
-        if is_fortran:
-            shape = list(readshape)
-        else:
-            shape = list(readshape)[::-1]
-
-        total_size = shape[0] * shape[1] * shape[2]
-
-        max_size = self.GetTargetSize()
-
         try:
+            outData = vtk.vtkImageData.GetData(outInfo)
+
+            if self.GetFileName() is None:
+                raise Exception("FileName must be set.")
+
+            self.ReadDataSetInfo()
+
+            # get basic info
+            readshape = self.GetStoredArrayShape()
+            is_fortran = self.GetIsFortran()
+
+            if is_fortran:
+                shape = list(readshape)
+            else:
+                shape = list(readshape)[::-1]
+
+            total_size = shape[0] * shape[1] * shape[2]
+
+            max_size = self.GetTargetSize()
+
             if total_size < max_size:  # in this case we don't need to resample
                 self._SetSlicePerChunk(shape[2])
                 reader = self._GetInternalChunkReader()
@@ -945,11 +952,12 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
                     resampled_image.CopyAndCastFrom(
                         resampler.GetOutput(), extent)
                     self.UpdateProgress(i / num_chunks)
-
         except Exception as e:
-            print(e)
+            raise Exception(e)
+
         finally:
-            shutil.rmtree(self._GetTempDir())
+            if self._GetTempDir() is not None:
+                shutil.rmtree(self._GetTempDir())
 
         return 1
 
@@ -967,7 +975,7 @@ class cilNumpyResampleReader(cilBaseResampleReader):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
         super(cilNumpyResampleReader, self).__init__()
 
-        self.__FileName = 1
+        self.__FileName = None
 
     def ReadNpyHeader(self):
         # extract info from the npy header
@@ -1011,22 +1019,23 @@ class cilNumpyResampleReader(cilBaseResampleReader):
     def GetFileName(self):
         return self.__FileName
 
+    def ReadDataSetInfo(self):
+        self.ReadNpyHeader()
+
 
 class cilHDF5ResampleReader(cilBaseResampleReader):
 
     def __init__(self):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
         super(cilHDF5ResampleReader, self).__init__()
-
-        # TODO: work out why not set by baseclass constructor
-        self.__FileName = 1
+        self.__FileName = None
         self.__DatasetName = None
 
     def SetDatasetName(self, value):
         print(value, self.__DatasetName)
         if value != self.__DatasetName:
             self.__DatasetName = value
-            if self.GetFileName() != 1:
+            if self.GetFileName() is not None:
                 self.ReadDataSetInfo()
 
     def SetFileName(self, value):
@@ -1046,6 +1055,8 @@ class cilHDF5ResampleReader(cilBaseResampleReader):
         reader.SetFileName(self.GetFileName())
         if self.GetDatasetName() is not None:
             reader.SetDatasetName(self.GetDatasetName())
+        else:
+            raise Exception("DataSetName must be set.")
         shape = reader.GetDimensions()
         # This is because the HDF5Reader already swaps the order:
         self.SetIsFortran(True)
@@ -1061,6 +1072,8 @@ class cilHDF5ResampleReader(cilBaseResampleReader):
         reader.SetFileName(self.GetFileName())
         if self.GetDatasetName() is not None:
             reader.SetDatasetName(self.GetDatasetName())
+        else:
+            raise Exception("DataSetName must be set.")
         self.SetOrigin(reader.GetOrigin())
         # Here we read just the chunk from the hdf5 file:
         cropped_reader = HDF5SubsetReader()
@@ -1093,7 +1106,7 @@ class cilMetaImageResampleReader(cilBaseResampleReader):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
         super(cilMetaImageResampleReader, self).__init__()
 
-        self.__FileName = 1
+        self.__FileName = None
         self.__CompressedData = False
         self.__ElementSpacing = [1, 1, 1]
 
@@ -1183,6 +1196,9 @@ class cilMetaImageResampleReader(cilBaseResampleReader):
     def SetCompressedData(self, value):
         self.__CompressedData = value
 
+    def ReadDataSetInfo(self):
+        self.ReadMetaImageHeader()
+
 
 class cilBaseCroppedReader(VTKPythonAlgorithmBase):
     '''vtkAlgorithm to crop in  the z direction
@@ -1193,7 +1209,7 @@ class cilBaseCroppedReader(VTKPythonAlgorithmBase):
     def __init__(self):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
 
-        self.__FileName = 1
+        self.__FileName = None
         self.__IsFortran = False
         self.__BigEndian = False
         self.__FileHeaderLength = 0
@@ -1466,7 +1482,7 @@ class cilNumpyCroppedReader(cilBaseCroppedReader):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
         super(cilNumpyCroppedReader, self).__init__()
 
-        self.__FileName = 1
+        self.__FileName = None
         self.__TargetSize = 256*256*256
         self.__IsFortran = False
         self.__BigEndian = False
@@ -1552,7 +1568,7 @@ class cilMetaImageCroppedReader(cilBaseCroppedReader):
         VTKPythonAlgorithmBase.__init__(self, nInputPorts=0, nOutputPorts=1)
         super(cilMetaImageCroppedReader, self).__init__()
 
-        self.__FileName = 1
+        self.__FileName = None
         self.__TargetSize = 256*256*256
         self.__IsFortran = False
         self.__BigEndian = False

--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -754,6 +754,10 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
         return self.__IsAcquisitionData
 
     def ReadDataSetInfo(self):
+        '''Not implemented for Base class
+        Tries to read info for about dataset from given file
+        Will raise specific errors if inputs required for 
+        filetype are not set.'''
         pass
 
     def _GetInternalChunkReader(self):

--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -755,9 +755,9 @@ class cilBaseResampleReader(VTKPythonAlgorithmBase):
 
     def ReadDataSetInfo(self):
         '''Not implemented for Base class
-        Tries to read info for about dataset from given file
+        Tries to read info about dataset from given file
         Will raise specific errors if inputs required for 
-        filetype are not set.'''
+        file type are not set.'''
         pass
 
     def _GetInternalChunkReader(self):

--- a/Wrappers/Python/ccpi/viewer/utils/error_handling.py
+++ b/Wrappers/Python/ccpi/viewer/utils/error_handling.py
@@ -1,0 +1,49 @@
+class ErrorObserver:
+
+    def __init__(self, callback_fn=print):
+        '''
+        Parameters:
+        -----------
+        callback_fn : function, default print
+            is called when an error occurs. It acts on the error message (str)
+            so must be a function that takes a string as a parameter.
+        '''
+        self.__error_occurred = False
+        self.__get_error_message = None
+        self.CallDataType = 'string0'
+        self.callback_fn = callback_fn
+
+    def __call__(self, obj, event, message):
+        self.__error_occurred = True
+        self.__get_error_message = message
+        #self.callback_fn(self.__get_error_message)
+        print(self.__get_error_message)
+
+    def error_occurred(self):
+        occ = self.__error_occurred
+        self.__error_occurred = False
+        return occ
+
+    def get_error_message(self):
+        return self.__get_error_message
+
+
+
+class EndObserver:
+    ''' Occurs when the observed Algorithm finishes
+    '''
+    def __init__(self, error_observer, callback_fn):
+        '''
+        Parameters
+        ----------
+        error_observer: ErrorObserver
+            the error observer attached to the object the EndObserver is attached to
+        callback_fn: function
+            function to run if an error hasn't been identified by the error_observer'''
+        self.callback_fn = callback_fn
+        self.error_observer = error_observer
+        self.CallDataType = 'string0'
+
+    def __call__(self, obj, event):
+        if not self.error_observer.error_occurred():
+            self.callback_fn()

--- a/Wrappers/Python/ccpi/viewer/utils/error_handling.py
+++ b/Wrappers/Python/ccpi/viewer/utils/error_handling.py
@@ -1,3 +1,6 @@
+# See examples/error_observer.py for an example of using the ErrorObserver
+# and EndObserver.
+
 class ErrorObserver:
 
     def __init__(self, callback_fn=print):

--- a/Wrappers/Python/ccpi/viewer/utils/error_handling.py
+++ b/Wrappers/Python/ccpi/viewer/utils/error_handling.py
@@ -19,8 +19,7 @@ class ErrorObserver:
     def __call__(self, obj, event, message):
         self.__error_occurred = True
         self.__get_error_message = message
-        #self.callback_fn(self.__get_error_message)
-        print(self.__get_error_message)
+        self.callback_fn(self.__get_error_message)
 
     def error_occurred(self):
         occ = self.__error_occurred

--- a/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
+++ b/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
@@ -60,6 +60,8 @@ class HDF5Reader(VTKPythonAlgorithmBase):
         self.__4DIndex = 0
 
     def RequestData(self, request, inInfo, outInfo):
+        if self.__DatasetName is None:
+            raise Exception("DataSetName must be set.")
         with h5py.File(self.__FileName, 'r') as f:
             info = outInfo.GetInformationObject(0)
             shape = np.shape(f[self.__DatasetName])
@@ -108,6 +110,8 @@ class HDF5Reader(VTKPythonAlgorithmBase):
             # Note that we flip the shape because VTK is Fortran order
             # whereas h5py reads in C order. When writing we pretend that the
             # data was C order so we have to flip the extents/dimensions.
+            if self.__DatasetName is None:
+                raise Exception("DataSetName must be set.")
             return f[self.__DatasetName].shape[::-1]
 
     def GetOrigin(self):

--- a/Wrappers/Python/examples/error_observer.py
+++ b/Wrappers/Python/examples/error_observer.py
@@ -13,13 +13,19 @@ to reading a HDF5 file
 if __name__ == "__main__":
     hdf5_name = r'C:\Users\lhe97136\Work\Data\24737_fd_normalised.nxs'
     readerhdf5 = cilHDF5ResampleReader()
-    error_obs = ErrorObserver()
-    end_obs = EndObserver(error_observer=error_obs, callback_fn = lambda: iviewer(readerhdf5.GetOutputDataObject(0), readerhdf5.GetOutputDataObject(0)))
+    ''' Create the error observer and attach it to the hdf5 reader. If an error occurs,
+     it will run the callback_fn, which is given the error message as an input.
+     So in this case it will print the error message.'''
+    error_obs = ErrorObserver(callback_fn=print)
     readerhdf5.AddObserver(vtk.vtkCommand.ErrorEvent, error_obs)
+    ''' Create the end observer and attach it to the hdf5 reader.
+    When the function it calls finishes, it checks the given error observer to see if an error occurred.
+    If not, it then runs the callback_fn. In this case, it displays the hdf5 image in the iviewer.'''
+    end_obs = EndObserver(error_observer=error_obs, callback_fn = lambda: iviewer(readerhdf5.GetOutputDataObject(0), readerhdf5.GetOutputDataObject(0)))
     readerhdf5.AddObserver(vtk.vtkCommand.EndEvent, end_obs)
     readerhdf5.SetFileName(hdf5_name)
-    # With this commented, we get an exception due to DatasetName not being set.
-    # Uncommenting this runs the callback_fn in the EndEvent:
-    # readerhdf5.SetDatasetName("entry1/tomo_entry/data/data")
+    ''' With this commented, we get an exception due to DatasetName not being set.
+    Uncommenting this runs the callback_fn in the EndEvent: '''
+    #readerhdf5.SetDatasetName("entry1/tomo_entry/data/data")
     readerhdf5.Update()
 

--- a/Wrappers/Python/examples/error_observer.py
+++ b/Wrappers/Python/examples/error_observer.py
@@ -1,0 +1,25 @@
+
+import vtk
+from ccpi.viewer.iviewer import iviewer
+from ccpi.viewer.utils.conversion import cilHDF5ResampleReader
+from ccpi.viewer.utils.error_handling import EndObserver, ErrorObserver
+
+'''
+An example which shows attaching an error observer and end observer
+to reading a HDF5 file
+'''        
+
+
+if __name__ == "__main__":
+    hdf5_name = r'C:\Users\lhe97136\Work\Data\24737_fd_normalised.nxs'
+    readerhdf5 = cilHDF5ResampleReader()
+    error_obs = ErrorObserver()
+    end_obs = EndObserver(error_observer=error_obs, callback_fn = lambda: iviewer(readerhdf5.GetOutputDataObject(0), readerhdf5.GetOutputDataObject(0)))
+    readerhdf5.AddObserver(vtk.vtkCommand.ErrorEvent, error_obs)
+    readerhdf5.AddObserver(vtk.vtkCommand.EndEvent, end_obs)
+    readerhdf5.SetFileName(hdf5_name)
+    # With this commented, we get an exception due to DatasetName not being set.
+    # Uncommenting this runs the callback_fn in the EndEvent:
+    # readerhdf5.SetDatasetName("entry1/tomo_entry/data/data")
+    readerhdf5.Update()
+


### PR DESCRIPTION
Also raises exceptions if essential inputs to readers are not set.
Example of using the ErrorObserver and EndObserver are in examples/error_observer.py

Closes #180 