### PR TITLE
Improve the slice widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## v22.x.x
+* Fixes enabling and disabling slice with 's' key in 3D viewer
+* Adds widget for slicing a volume with the 'c' key in the 3D viewer
+* Add light to 3D viewer
+* Add a few utility methods for volume rendering in 3D viewer
+
 ## v22.1.0
 * requires vtk version >= 9.0.3
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -276,6 +276,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
                 plane.SetOrigin( *foc )
                 
                 proj = cam.GetDirectionOfProjection()
+                proj = [x + 0.3 for x in list(proj)]
                 plane.SetNormal( *proj )
                 rep.SetPlane(plane)
                 rep.UpdatePlacement()


### PR DESCRIPTION
Makes the following changes:

-  Scales size of bounding box with size of image
- Shows slice widget when c is pressed without needing any mouse presses
- Turns off the 2D slice when the slice widget is enabled
- Orients the clipping plane to be slightly skewed from the direction of the camera, so the handle can be seen

Example of automatic slicing direction when viewing along the z axis:

![image](https://user-images.githubusercontent.com/60604372/159915629-4d344c37-3e51-4d93-bafb-e6c945031fc0.png)

View of the bounding box and plane:

![Capture](https://user-images.githubusercontent.com/60604372/159915782-fea2b511-ac08-4141-884e-ac6525b81750.JPG)

