### PR TITLE
Improvements to iviewer example

### DIFF
--- a/Wrappers/Python/ccpi/viewer/iviewer.py
+++ b/Wrappers/Python/ccpi/viewer/iviewer.py
@@ -13,6 +13,9 @@ class SingleViewerCenterWidget(QtWidgets.QMainWindow):
         QtWidgets.QMainWindow.__init__(self, parent)
         
         self.frame = QCILViewerWidget(viewer=viewer, shape=(600,600))
+
+        if viewer == viewer3D:
+            self.frame.viewer.setVolumeRenderOpacityMethod('scalar')
                 
         self.setCentralWidget(self.frame)
     
@@ -43,7 +46,8 @@ class TwoLinkedViewersCenterWidget(QtWidgets.QMainWindow):
         # For the head example we have to set the method to scalar so that
         # the volume render can be seen
         # may need to comment this out for other datasets
-        self.frame2.viewer.setVolumeRenderOpacityMethod('scalar')
+        if viewers[1] == viewer3D:
+            self.frame2.viewer.setVolumeRenderOpacityMethod('scalar')
                 
         # Initially link viewers
         self.linkedViewersSetup()


### PR DESCRIPTION
Allows selection of viewer types in the case that 2 images are displayed. This means we can view an image in both 2D and 3D at the same time - in the example when iviewer.py is run, it does this with the head image.

Changes the default VolumeOpacityMethod in the 3D viewer created in the example (if present) to 'scalar' - this is optimal for the head dataset - as with the default 'gradient' method, the volume render can't be seen - only the teeth very faintly!