### PR TITLE
Fix updating of volume opacity method in 3D viewer

### DIFF
--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -752,8 +752,16 @@ class CILViewer():
         else:
             cmin = self.volume_colormap_limits[0]
             cmax = self.volume_colormap_limits[1]
+
+        ia = vtk.vtkImageHistogramStatistics()
+        ia.SetInputData(self.img3D)
+        ia.SetAutoRangePercentiles(10,90)
+        ia.Update()
+        colour_cmin, colour_cmax = ia.GetAutoRange()
+
       
-        colors = colormaps.CILColorMaps.get_color_transfer_function(self.getVolumeColorMapName(), (cmin, cmax))
+        # get cmin, cmax from image
+        colors = colormaps.CILColorMaps.get_color_transfer_function(self.getVolumeColorMapName(), (colour_cmin, colour_cmax))
 
         # mapping values in the image to opacity:
         x = self.getMappingArray(color_num, method)

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -687,6 +687,10 @@ class CILViewer():
         colors, opacity = self.getColorOpacityForVolumeRender()
 
         self.volume_property.SetColor(colors)
+
+        self.setDefaultScalarOpacity(self.volume_property.GetScalarOpacity())
+        self.setDefaultGradientOpacity(self.volume_property.GetGradientOpacity())
+
         if self.getVolumeRenderOpacityMethod() == 'gradient':
             self.volume_property.SetGradientOpacity(opacity)
         elif self.getVolumeRenderOpacityMethod() == 'scalar':
@@ -716,10 +720,24 @@ class CILViewer():
         if not hasattr(self, '_vol_render_opacity_method'):
             self.setVolumeRenderOpacityMethod('gradient')
         return self._vol_render_opacity_method
+
     def setVolumeRenderOpacityMethod(self, method='gradient'):
         if method in ['scalar', 'gradient']:
             self._vol_render_opacity_method = method
+            self.updateVolumePipeline()
         # if the method is not supported it does nothing???
+
+    def setDefaultScalarOpacity(self, opacity):
+        self.default_scalar_opacity = opacity
+    
+    def setDefaultGradientOpacity(self, opacity):
+        self.default_gradient_opacity = opacity
+
+    def getDefaultScalarOpacity(self):
+        return self.default_scalar_opacity
+
+    def getDefaultGradientOpacity(self):
+        return self.default_gradient_opacity
 
     def getColorOpacityForVolumeRender(self, percentiles=(80.,99.), color_num=255, max_opacity=0.1):
         '''Defines the color and opacity tables
@@ -835,7 +853,16 @@ class CILViewer():
             opacity = colormaps.CILColorMaps.get_opacity_transfer_function(x, 
             colormaps.relu, cmin, cmax, scaling)
             self.volume_property.SetColor(colors)
-            self.volume_property.SetScalarOpacity(opacity)
+
+            # Update whether we use our calculated opacity as the scalar or gradient opacity
+            # Also return the other opacity type to its default value:
+            if self.getVolumeRenderOpacityMethod() == 'gradient':
+                self.volume_property.SetScalarOpacity(self.getDefaultScalarOpacity()) 
+                self.volume_property.SetGradientOpacity(opacity)
+                 
+            elif self.getVolumeRenderOpacityMethod() == 'scalar': 
+                self.volume_property.SetGradientOpacity(self.getDefaultGradientOpacity())
+                self.volume_property.SetScalarOpacity(opacity)
         
 
     def setVolumeColorLevelWindow(self, cmin, cmax):

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -803,7 +803,7 @@ class CILViewer():
             the percentiles on the image values upon which the colours will be mapped to
         '''
         cmin, cmax = self.getVolumeMapWindow((min, max), 'scalar')
-        self.setVolumeColorLevelWindow(cmin, cmax, update_pipeline)
+        self.setVolumeColorWindow(cmin, cmax, update_pipeline)
 
     def setGradientOpacityWindow(self, min, max, update_pipeline=True):
         '''
@@ -860,7 +860,7 @@ class CILViewer():
         '''
         return self.scalar_opacity_limits
 
-    def setVolumeColorLevelWindow(self, min, max, update_pipeline=True):
+    def setVolumeColorWindow(self, min, max, update_pipeline=True):
         '''
         Parameters
         -----------
@@ -875,7 +875,7 @@ class CILViewer():
         if update_pipeline:
             self.updateVolumePipeline()
 
-    def getVolumeColorLevelWindow(self):
+    def getVolumeColorWindow(self):
         '''
         Returns
         -----------
@@ -1061,7 +1061,9 @@ class CILViewer():
             # Update whether we use our calculated opacity as the scalar or gradient opacity
             if self.getVolumeRenderOpacityMethod() == 'gradient':
                 # Also return the scalar opacity to its default value:
-                self.volume_property.SetScalarOpacity(self._getDefaultScalarOpacityFunction()) 
+                # If we don't do this then the gradient opacity changes depending on what the
+                # user set for the scalar opacity - not sure we want this:
+                self.volume_property.SetScalarOpacity(self._getDefaultScalarOpacityFunction())
                 self.volume_property.DisableGradientOpacityOff()
                 self.volume_property.SetGradientOpacity(opacity)
                  

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -974,7 +974,7 @@ class CILViewer():
             'gradient' - returns full range of values in image gradient
         '''
 
-        self.getVolumeMapWindow((0,100), method)
+        return self.getVolumeMapWindow((0,100), method)
 
     def getMappingArray(self, color_num, method):
         '''

--- a/Wrappers/Python/ccpi/viewer/utils/colormaps.py
+++ b/Wrappers/Python/ccpi/viewer/utils/colormaps.py
@@ -1108,7 +1108,7 @@ def relu(x, xmin, xmax, scaling=1):
         if val < xmin or val > xmax:
             out.append(0)
         else:
-            out.append((val - xmin)*scaling / dx)
+            out.append(scaling * ((val - xmin) / dx))
     return numpy.asarray(out)
 
 

--- a/Wrappers/Python/ccpi/viewer/utils/colormaps.py
+++ b/Wrappers/Python/ccpi/viewer/utils/colormaps.py
@@ -1108,7 +1108,7 @@ def relu(x, xmin, xmax, scaling=1):
         if val < xmin or val > xmax:
             out.append(0)
         else:
-            out.append((val - xmin) / dx)
+            out.append((val - xmin)*scaling / dx)
     return numpy.asarray(out)
 
 

--- a/Wrappers/Python/examples/opacity_in_viewer.py
+++ b/Wrappers/Python/examples/opacity_in_viewer.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     vtk.vtkOutputWindow.SetInstance(err)
  
     reader = vtk.vtkMetaImageReader()
-    reader.SetFileName(r'D:\lhe97136\Work\Data\CILViewer\head.mha')
+    reader.SetFileName(r'head.mha')
     reader.Update()
 
 

--- a/Wrappers/Python/examples/opacity_in_viewer.py
+++ b/Wrappers/Python/examples/opacity_in_viewer.py
@@ -1,0 +1,96 @@
+import sys
+import vtk
+from PySide2 import QtCore, QtWidgets
+from PySide2.QtCore import Qt
+from ccpi.viewer import viewer2D, viewer3D
+from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
+import ccpi.viewer.viewerLinker as vlink
+from ccpi.viewer.utils.conversion import Converter
+import numpy as np
+from eqt.ui.UIFormWidget import FormWidget, FormDockWidget
+
+from ccpi.viewer.utils.conversion import cilHDF5ResampleReader
+from ccpi.viewer.iviewer import SingleViewerCenterWidget
+from PySide2.QtWidgets import (QCheckBox, QComboBox, QDoubleSpinBox,
+                               QFileDialog, QFormLayout, QFrame, QGroupBox,
+                               QHBoxLayout, QLabel, QLineEdit, QPushButton,
+                               QSlider, QSpinBox)
+
+from qdarkstyle.dark.palette import DarkPalette
+from qdarkstyle.light.palette import LightPalette
+import qdarkstyle
+
+class OpacityViewerWidget(SingleViewerCenterWidget):
+
+    def __init__(self, parent = None, viewer=viewer3D):
+        SingleViewerCenterWidget.__init__(self, parent)
+        
+        self.frame = QCILViewerWidget(viewer=viewer, shape=(600,600))
+                
+        self.setCentralWidget(self.frame)
+
+        self.create_settings_dockwidget()
+
+        self.set_app_style()
+    
+        self.show()
+
+    def set_input(self, data):
+        self.frame.viewer.setInputData(data)
+
+    def create_settings_dockwidget(self):
+        form_dock_widget = FormDockWidget()
+        drop_down = QComboBox()
+        drop_down.addItems(['gradient', 'scalar'])
+        drop_down.currentTextChanged.connect(lambda: self.frame.viewer.setVolumeRenderOpacityMethod(drop_down.currentText()))
+        form_dock_widget.addWidget( drop_down, "Select Opacity Method:", 'select_opacity')
+        self.addDockWidget(Qt.TopDockWidgetArea, form_dock_widget)
+
+    def set_app_style(self):
+        '''Sets app stylesheet '''
+        style = qdarkstyle.load_stylesheet(palette=DarkPalette)
+        self.setStyleSheet(style)
+
+
+class viewer_window(object):
+    '''
+    a Qt interactive viewer with one single dataset
+    Parameters
+    ----------
+    data: vtkImageData
+        image to be displayed       
+    '''
+    def __init__(self, data):
+        '''Creator'''
+        app = QtWidgets.QApplication(sys.argv)
+        self.app = app
+        
+        self.setUp(data)
+        self.show()
+
+    def setUp(self, data):
+        window = OpacityViewerWidget()        
+        window.set_input(data)
+        self.window = window
+        self.has_run = None
+
+    def show(self):
+        if self.has_run is None:
+            self.has_run = self.app.exec_()
+        else:
+            print ('No instance can be run interactively again. Delete and re-instantiate.')
+
+if __name__ == "__main__":
+
+    err = vtk.vtkFileOutputWindow()
+    err.SetFileName("viewer.log")
+    vtk.vtkOutputWindow.SetInstance(err)
+ 
+    reader = vtk.vtkMetaImageReader()
+    reader.SetFileName(r'D:\lhe97136\Work\Data\CILViewer\head.mha')
+    reader.Update()
+
+
+    viewer_window(reader.GetOutput())
+
+

--- a/Wrappers/Python/examples/opacity_in_viewer.py
+++ b/Wrappers/Python/examples/opacity_in_viewer.py
@@ -1,25 +1,21 @@
 import sys
+
 import vtk
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtCore import Qt
-from ccpi.viewer import viewer2D, viewer3D
-from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
-import ccpi.viewer.viewerLinker as vlink
-from ccpi.viewer.utils.conversion import Converter
-import numpy as np
-from eqt.ui.UIFormWidget import FormWidget, FormDockWidget
-
-from ccpi.viewer.utils.conversion import cilHDF5ResampleReader
+from ccpi.viewer import viewer3D
 from ccpi.viewer.iviewer import SingleViewerCenterWidget
-from PySide2.QtWidgets import (QCheckBox, QComboBox, QDoubleSpinBox,
-                               QFileDialog, QFormLayout, QFrame, QGroupBox,
-                               QHBoxLayout, QLabel, QLineEdit, QPushButton,
-                               QSlider, QSpinBox)
+from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
+from eqt.ui.UIFormWidget import FormDockWidget
+from PySide2 import QtWidgets
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QComboBox
 
-from qdarkstyle.dark.palette import DarkPalette
-from qdarkstyle.light.palette import LightPalette
-import qdarkstyle
-
+try:
+    import qdarkstyle
+    from qdarkstyle.dark.palette import DarkPalette
+    set_style = True
+except:
+    set_style = False
+    
 class OpacityViewerWidget(SingleViewerCenterWidget):
 
     def __init__(self, parent = None, viewer=viewer3D):
@@ -31,7 +27,8 @@ class OpacityViewerWidget(SingleViewerCenterWidget):
 
         self.create_settings_dockwidget()
 
-        self.set_app_style()
+        if set_style:
+            self.set_app_style()
     
         self.show()
 


### PR DESCRIPTION
- Closes: #227 
- Fixes the way the gradient opacity is set so that it is mapping the values in the image gradient
- Adds methods for setting and getting the window or percentiles for:
   - The colour
   - The scalar opacity (used if setVolumeRenderOpacityMethod is set to scalar)
   - The gradient opacity (used if setVolumeRenderOpacityMethod is set to gradient)
   https://github.com/vais-ral/CILViewer/blob/03701d1949dde7f42b66a1c45f86bef337f108c6/Wrappers/Python/ccpi/viewer/CILViewer.py#L775-L886
- Adds method for getting the full range of image or gradient values: https://github.com/vais-ral/CILViewer/blob/03701d1949dde7f42b66a1c45f86bef337f108c6/Wrappers/Python/ccpi/viewer/CILViewer.py#L968-L977

- Makes an example with dropdown for updating opacity method:
![image](https://user-images.githubusercontent.com/60604372/166951409-7a024ca7-d54d-4035-a965-bf9bd1cb9d81.png)
![image](https://user-images.githubusercontent.com/60604372/166951525-b3e9f497-fc65-482f-802f-aec302589c77.png)

**Note backwards compatibility break:
setVolumeColorLevelWindow  has been renamed to: setVolumeColorWindow**