### PR TITLE
update camera position on 3D viewer when new image is loaded

### DIFF
--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -619,7 +619,6 @@ class CILViewer():
 
     def setInput3DData(self, imageData):
         self.img3D = imageData
-        self.installPipeline()
         if self.volume_render_initialised:
             if self.volume.GetVisibility():
                 if self.clipping_plane_initialised:
@@ -628,9 +627,9 @@ class CILViewer():
                     self.clipping_plane_initialised = False
                 self.installVolumeRenderActorPipeline()
                 self.volume.VisibilityOn()
-                self.updatePipeline()
             else:
                 self.volume_render_initialised = False
+        self.installPipeline()
 
     def setInputData(self, imageData):
         '''alias of setInput3DData'''


### PR DESCRIPTION
closes #232 

`installPipeline` updates the camera position. Previously this was called before the clipping planes and volume from the old image were deleted, so the camera position was not updated correctly.