### PR TITLE
Improvements to HDF5 readers and writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Increments number in name of file when saving render to PNG, so multiple captures can be made without them overwriting each other.
 * Add vtkImageResampler, which downsamples from memory
 * When a new 3D image is input, volume render is updated and clipping planes are cleared
+* No need to specify VTK array name when writing to HDF5
+* Allow setting both 4D index and 4D slice index when reading 4D HDF5 dataset
 
 ## v22.1.0
 * requires vtk version >= 9.0.3

--- a/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
+++ b/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
@@ -17,7 +17,6 @@ def write_image_data_to_hdf5(filename, data, dataset_name, attributes={}):
         data: vtkImageData - image data to write.
         DatasetName: string - DatasetName for HDF5 dataset.
         attributes: dict - attributes to assign to HDF5 dataset.
-        array_name: string - name of array to read points from the vtkImageData
     '''
 
     with h5py.File(filename, "a") as f:

--- a/Wrappers/Python/test/test_hdf5.py
+++ b/Wrappers/Python/test/test_hdf5.py
@@ -35,7 +35,7 @@ class TestHDF5IO(unittest.TestCase):
             f.create_dataset('ImageData', data=self.input_3D_array)
 
         # Generate random 4D array and write to HDF5:
-        self.input_4D_array = np.random.random(size=(10, 5, 10, 6))
+        self.input_4D_array = np.random.random(size=(10, 7, 10, 6))
         self.hdf5_filename_4D = 'test_4D_data.h5'
         with h5py.File(self.hdf5_filename_4D, 'w') as f:
             f.create_dataset('ImageData', data=self.input_4D_array)
@@ -57,7 +57,8 @@ class TestHDF5IO(unittest.TestCase):
         reader = HDF5Reader()
         reader.SetFileName(self.hdf5_filename_4D)
         reader.SetDatasetName("ImageData")
-        reader.Set4DIndex(channel_index)
+        reader.Set4DSliceIndex(channel_index)
+        reader.Set4DIndex(0)
         reader.Update()
         array_image_data = reader.GetOutputDataObject(0)
         read_array = Converter.vtk2numpy(array_image_data)
@@ -93,14 +94,15 @@ class TestHDF5IO(unittest.TestCase):
     def test_read_cropped_hdf5_channel(self):
         # Test cropping the extent of a dataset
         channel_index = 5
-        cropped_array = self.input_4D_array[:, 1:2, 3:6, 0:3][5]
+        cropped_array = self.input_4D_array[1:2, channel_index, 3:6, 0:3]
         hdf5_filename = 'test_numpy_data.h5'
         with h5py.File(hdf5_filename, 'w') as f:
             f.create_dataset('ImageData', data=self.input_4D_array)
         reader = HDF5Reader()
         reader.SetFileName(self.hdf5_filename_4D)
         reader.SetDatasetName("ImageData")
-        reader.Set4DIndex(channel_index)
+        reader.Set4DSliceIndex(channel_index)
+        reader.Set4DIndex(1)
         cropped_reader = HDF5SubsetReader()
         cropped_reader.SetInputConnection(reader.GetOutputPort())
         # NOTE: the extent is in vtk so is in fortran order, whereas
@@ -121,8 +123,7 @@ class TestHDF5IO(unittest.TestCase):
         self.hdf5_filename_RT = "test_image_data.hdf5"
 
         write_image_data_to_hdf5(
-            self.hdf5_filename_RT, image_data, dataset_name='RTData',
-            array_name='RTData')
+            self.hdf5_filename_RT, image_data, dataset_name='RTData')
 
         # Test reading hdf5:
         reader = HDF5Reader()


### PR DESCRIPTION
- No need to specify VTK array name when writing to HDF5
- Use single instead of double underscores for variable names
- Allow setting both 4D index and 4D slice index
- Add checks for whether filename has been set before trying to read it
- Update unit tests to cover above changes