### PR TITLE
Fix downsamplers so they take into account number of bytes per element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v22.x.x
+* When a new image is loaded on the 3D viewer, reset camera position, slice and volume orientation and visibility, and clipping planes.
+
 ## v22.1.1
 * Changes released in 22.0.1, but also requires vtk version >= 9.0.3
 

--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -1131,7 +1131,7 @@ class cilBaseResampleReader(cilBaseReader):
             else:
                 shape = list(readshape)[::-1]
 
-            total_size = shape[0] * shape[1] * shape[2]
+            total_size = shape[0] * shape[1] * shape[2] * self.GetBytesPerElement()
 
             max_size = self.GetTargetSize()
 
@@ -1701,6 +1701,11 @@ class vtkImageResampler(VTKPythonAlgorithmBase):
         ''' Get the total target size to downsample image to, in bytes.'''
         return self._TargetSize
 
+    def GetBytesPerElement(self):
+        ''' Get number of bytes per element'''
+        if hasattr(self, '_BytesPerElement'):
+            return self._BytesPerElement
+
     def GetOutput(self):
         return self.GetOutputDataObject(0)
 
@@ -1709,6 +1714,7 @@ class vtkImageResampler(VTKPythonAlgorithmBase):
         self._Origin = inData.GetOrigin()
         self._Extent = inData.GetExtent()
         self._StoredArrayShape = (self._Extent[1]+1, (self._Extent[3]+1), (self._Extent[5]+1))
+        self._BytesPerElement = Converter.vtkType_to_bytes[inData.GetScalarType()]
 
     def GetElementSpacing(self):
         ''' Returns the spacing of the input dataset as a tuple'''
@@ -1736,7 +1742,7 @@ class vtkImageResampler(VTKPythonAlgorithmBase):
         extent = self.GetExtent()
         shape = self.GetStoredArrayShape()
 
-        total_size = shape[0] * shape[1] * shape[2]
+        total_size = shape[0] * shape[1] * shape[2] * self.GetBytesPerElement()
 
         max_size = self.GetTargetSize()
 

--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -1334,10 +1334,8 @@ class cilHDF5ResampleReader(cilBaseResampleReader, cilBaseHDF5Reader):
         # Here we read just the chunk from the hdf5 file:
         cropped_reader = HDF5SubsetReader()
         cropped_reader.SetInputConnection(reader.GetOutputPort())
-        dims = self.GetStoredArrayShape()
         # Set default extent to full extent:
-        cropped_reader.SetUpdateExtent(
-            (0, dims[0]-1, 0, dims[1]-1, 0, dims[2]-1))
+        cropped_reader.SetUpdateExtent((0, -1, 0, -1, 0, -1))
         self._ChunkReader = cropped_reader
         return cropped_reader
 
@@ -1346,6 +1344,9 @@ class cilHDF5ResampleReader(cilBaseResampleReader, cilBaseHDF5Reader):
         start_slice in the z direction'''
         num_slices_per_chunk = self._GetNumSlicesPerChunk()
         end_slice = start_slice + num_slices_per_chunk - 1
+        end_z_value = self.GetStoredArrayShape()[2]-1
+        if end_slice > end_z_value:
+            end_slice = end_z_value
         if start_slice < 0:
             raise ValueError('{} ERROR: Start slice cannot be negative.'
                              .format(self.__class__.__name__))
@@ -1653,6 +1654,8 @@ class cilHDF5CroppedReader(cilBaseCroppedReader, cilBaseHDF5Reader):
         reader.Update()
         read_data = reader.GetOutput()
         outData.ShallowCopy(read_data)
+
+        return 1
 
 
 # ------------ RESAMPLE FROM MEMORY: ------------------------------------------------------------------------------

--- a/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
+++ b/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
@@ -204,6 +204,7 @@ class HDF5SubsetReader(VTKPythonAlgorithmBase):
                 vtk.vtkStreamingDemandDrivenPipeline.WHOLE_EXTENT())
             set_extent = list(info.Get(
                 vtk.vtkStreamingDemandDrivenPipeline.UPDATE_EXTENT()))
+            
             for i, value in enumerate(set_extent):
                 if value == -1:
                     set_extent[i] = whole_extent[i]
@@ -211,13 +212,13 @@ class HDF5SubsetReader(VTKPythonAlgorithmBase):
                     if i % 2 == 0:
                         if value < whole_extent[i]:
                             raise ValueError("Requested extent {}\
-                                is outside of original image extent {}".format(
-                                set_extent, whole_extent))
+                                is outside of original image extent {} as {}<{}".format(
+                                set_extent, whole_extent, value, whole_extent[i]))
                     else:
                         if value > whole_extent[i]:
                             raise ValueError("Requested extent {}\
-                                is outside of original image extent {}".format(
-                                set_extent, whole_extent))
+                                is outside of original image extent {} as {}>{}".format(
+                                set_extent, whole_extent, value, whole_extent[i]))
             
             self.SetUpdateExtent(set_extent)
 

--- a/Wrappers/Python/test/test_hdf5.py
+++ b/Wrappers/Python/test/test_hdf5.py
@@ -65,7 +65,7 @@ class TestHDF5IO(unittest.TestCase):
         np.testing.assert_array_equal(
             self.input_4D_array[channel_index], read_array)
 
-    def test_read_cropped_hdf5(self):
+    def test_hdf5_subset_reader(self):
         # With the subset reader: -----------------------------
         # Test cropping the extent of a dataset
         cropped_array = self.input_3D_array[1:3, 3:6, 0:3]
@@ -81,7 +81,10 @@ class TestHDF5IO(unittest.TestCase):
         array_image_data = cropped_reader.GetOutputDataObject(0)
         read_cropped_array = Converter.vtk2numpy(array_image_data)
         np.testing.assert_array_equal(cropped_array, read_cropped_array)
-        # With the Cropped reader: -----------------------------
+
+    def test_read_cropped_hdf5_reader(self):
+        # # With the Cropped reader: -----------------------------
+        cropped_array = self.input_3D_array[1:3, 3:6, 0:3]
         reader = cilHDF5CroppedReader()
         reader.SetFileName(self.hdf5_filename_3D)
         reader.SetDatasetName("ImageData")

--- a/Wrappers/Python/test/test_hdf5.py
+++ b/Wrappers/Python/test/test_hdf5.py
@@ -154,7 +154,7 @@ class TestHDF5IO(unittest.TestCase):
         resulting_shape = (extent[1]+1, (extent[3]+1), (extent[5]+1))
         og_shape = np.shape(self.input_3D_array)
         og_shape = (og_shape[2], og_shape[1], og_shape[0])
-        og_size = og_shape[0]*og_shape[1]*og_shape[2]
+        og_size = og_shape[0]*og_shape[1]*og_shape[2]*readerhdf5.GetBytesPerElement()
         expected_shape = calculate_target_downsample_shape(
             target_size, og_size, og_shape)
         self.assertEqual(resulting_shape, expected_shape)

--- a/Wrappers/Python/test/test_resample_readers.py
+++ b/Wrappers/Python/test/test_resample_readers.py
@@ -28,7 +28,9 @@ class TestResampleReaders(unittest.TestCase):
     def setUp(self):
         # Generate random 3D array and write to HDF5:
         np.random.seed(1)
-        self.input_3D_array = np.random.randint(10, size=(5, 10, 6), dtype=np.uint8)
+        bits = 16
+        self.bytes_per_element = int(bits/8)
+        self.input_3D_array = np.random.randint(10, size=(5, 10, 6), dtype=eval(f"np.uint{bits}"))
         bytes_3D_array = bytes(self.input_3D_array)
         self.raw_filename_3D = 'test_3D_data.raw'
         with open(self.raw_filename_3D, 'wb') as f:
@@ -36,7 +38,7 @@ class TestResampleReaders(unittest.TestCase):
 
         # write header to go with raw file
         self.mhd_filename_3D = 'raw_header.mhd'
-        typecode = 'uint8'
+        typecode = f'uint{bits}'
         big_endian = False
         header_length = 0
         shape = np.shape(self.input_3D_array)
@@ -77,7 +79,7 @@ class TestResampleReaders(unittest.TestCase):
         extent = image.GetExtent()
         resulting_shape = (extent[1]+1, (extent[3]+1), (extent[5]+1))
         og_shape = (og_shape[2], og_shape[1], og_shape[0])
-        og_size = og_shape[0]*og_shape[1]*og_shape[2]
+        og_size = og_shape[0]*og_shape[1]*og_shape[2]*self.bytes_per_element
         expected_shape = calculate_target_downsample_shape(
             target_size, og_size, og_shape)
         self.assertEqual(resulting_shape, expected_shape)
@@ -105,10 +107,10 @@ class TestResampleReaders(unittest.TestCase):
         reader.Update()
         image = reader.GetOutput()
         extent = image.GetExtent()
-        shape_not_acquisition = calculate_target_downsample_shape(
+        shape_acquisition = calculate_target_downsample_shape(
             target_size, og_size, og_shape, acq=True)
-        expected_size = shape_not_acquisition[0] * \
-            shape_not_acquisition[1]*shape_not_acquisition[2]
+        expected_size = shape_acquisition[0] * \
+            shape_acquisition[1]*shape_acquisition[2]
         resulting_shape = (extent[1]+1, (extent[3]+1), (extent[5]+1))
         resulting_size = resulting_shape[0] * \
             resulting_shape[1]*resulting_shape[2]
@@ -140,7 +142,7 @@ class TestResampleReaders(unittest.TestCase):
                 extent = image.GetExtent()
                 resulting_shape = (extent[1]+1, (extent[3]+1), (extent[5]+1))
                 og_shape = (og_shape[2], og_shape[1], og_shape[0])
-                og_size = og_shape[0]*og_shape[1]*og_shape[2]
+                og_size = og_shape[0]*og_shape[1]*og_shape[2]*self.bytes_per_element
                 expected_shape = calculate_target_downsample_shape(
                     target_size, og_size, og_shape)
                 self.assertEqual(resulting_shape, expected_shape)

--- a/Wrappers/Python/test/test_vtk_image_resampler.py
+++ b/Wrappers/Python/test/test_vtk_image_resampler.py
@@ -24,7 +24,9 @@ class TestVTKImageResampler(unittest.TestCase):
     def setUp(self):
         # Generate random 3D array and convert to VTK Image Data:
         np.random.seed(1)
-        self.input_3D_array = np.random.randint(10, size=(50, 10, 60), dtype=np.uint8)
+        bits = 16
+        self.bytes_per_element = int(bits/8)
+        self.input_3D_array = np.random.randint(10, size=(50, 10, 60), dtype=eval(f"np.uint{bits}"))
         self.input_vtk_image = Converter.numpy2vtkImage(self.input_3D_array)
         
 
@@ -44,7 +46,7 @@ class TestVTKImageResampler(unittest.TestCase):
         og_shape = np.shape(self.input_3D_array)
         resulting_shape = (extent[1]+1, (extent[3]+1), (extent[5]+1))
         og_shape = (og_shape[2], og_shape[1], og_shape[0])
-        og_size = og_shape[0]*og_shape[1]*og_shape[2]
+        og_size = og_shape[0]*og_shape[1]*og_shape[2]*self.bytes_per_element
         expected_shape = calculate_target_downsample_shape(
             target_size, og_size, og_shape)
         self.assertEqual(resulting_shape, expected_shape)


### PR DESCRIPTION
- also updated relevant unit tests
- fixed issue with incorrect extent being set in hdf5 readers [previously for the final chunk, sometimes it tried to read more data than was present in the array]
- prevented RequestData error - closes https://github.com/vais-ral/CILViewer/issues/179