### PR TITLE
Add an entrypoint for the web_app

### DIFF
--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -10,6 +10,8 @@ build:
   preserve_egg_dir: False 
   number: {{ GIT_DESCRIBE_NUMBER }}
   noarch: python
+  entry_points:
+    - cilwebapp = ccpi.web_viewer.web_app:main
   
 test:
   source_files:

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -11,7 +11,7 @@ build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   noarch: python
   entry_points:
-    - cilwebapp = ccpi.web_viewer.web_app:main
+    - web_cilviewer = ccpi.web_viewer.web_app:main
   
 test:
   source_files:

--- a/Wrappers/Python/setup.py
+++ b/Wrappers/Python/setup.py
@@ -72,7 +72,7 @@ setup(
     # could also include long_description, download_url, classifiers, etc.
     entry_points={
         'console_scripts': [
-            'cilwebapp = ccpi.web_viewer.web_app:main'
+            'web_cilviewer = ccpi.web_viewer.web_app:main'
         ]
     }
 )

--- a/Wrappers/Python/setup.py
+++ b/Wrappers/Python/setup.py
@@ -69,6 +69,10 @@ setup(
     license="Apache v2.0",
     keywords="3D data viewer",
     url="http://www.ccpi.ac.uk",  # project home page, if any
-
     # could also include long_description, download_url, classifiers, etc.
+    entry_points={
+        'console_scripts': [
+            'cilwebapp = ccpi.web_viewer.web_app:main'
+        ]
+    }
 )


### PR DESCRIPTION
Adds an entry point so we can easily start the web app from the command-line after pip installing the CILViewer to do this call:
`cilwebapp`