### PR TITLE
Add a Base Class for CILViewer and CILViewer2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - Backward incompatible rename of a few methods: 
     - Get/SetActiveSlice -> get/setActiveSlice, 
     - GetSliceOrientation -> getSliceOrientation, 
-    - setColourWindowLevel -> setColorWindowLevel, 
+    - setColourWindowLevel -> setSliceColorWindowLevel, 
     - getColourLevel -> getSliceColourLevel, 
     - getColourWindow -> getSliceColorWindow, 
     - setColourWindowLevel -> setSliceColorWindowLevel
@@ -27,6 +27,7 @@
   - fix definition of window range to be = max - min
 - colormaps: added get_color_transfer_function
 - added examples of running the 2D and 3D viewers without Qt
+- Added CILViewer base class
 
 ## v22.1.2
 * Changes released in 22.0.2, but also requires vtk version >= 9.0.3

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -16,12 +16,13 @@
 
 import numpy
 import vtk
-from ccpi.viewer.CILViewerBase import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
-                                       LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
-                                       SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
-from ccpi.viewer.utils import colormaps
-
+from ccpi.viewer  import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR,
+                         HELP_ACTOR, HISTOGRAM_ACTOR, LINEPLOT_ACTOR,
+                         OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR,
+                         SLICE_ORIENTATION_XY, SLICE_ORIENTATION_XZ,
+                         SLICE_ORIENTATION_YZ)
 from ccpi.viewer.CILViewerBase import CILViewerBase
+from ccpi.viewer.utils import colormaps
 
 
 class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
@@ -430,10 +431,7 @@ class CILViewer(CILViewerBase):
         CILViewerBase.__init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True)
         '''creates the rendering pipeline'''
 
-        # create a renderwindowinteractor
-        self.style = CILInteractorStyle(self)
-        self.iren.SetInteractorStyle(self.style)
-        self.iren.SetRenderWindow(self.renWin)
+        self.setInteractorStyle(CILInteractorStyle(self))
 
         self.sliceActorNo = 0
         # Render decimation
@@ -469,12 +467,6 @@ class CILViewer(CILViewerBase):
         self.volume_colormap_name = 'viridis'
         self.volume_render_initialised = False
         self.clipping_plane_initialised = False
-
-        self.iren.Initialize()
-
-    def getCamera(self):
-        '''returns the active camera'''
-        return self.ren.GetActiveCamera()
 
     def createPolyDataActor(self, polydata):
         '''returns an actor for a given polydata'''

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -16,11 +16,9 @@
 
 import numpy
 import vtk
-from ccpi.viewer  import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR,
-                         HELP_ACTOR, HISTOGRAM_ACTOR, LINEPLOT_ACTOR,
-                         OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR,
-                         SLICE_ORIENTATION_XY, SLICE_ORIENTATION_XZ,
-                         SLICE_ORIENTATION_YZ)
+from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
+                         LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
+                         SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
 from ccpi.viewer.CILViewerBase import CILViewerBase
 from ccpi.viewer.utils import colormaps
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -17,10 +17,9 @@
 import numpy
 import vtk
 from ccpi.viewer.CILViewerBase import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
-                                     LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
-                                     SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
+                                       LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
+                                       SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
 from ccpi.viewer.utils import colormaps
-
 
 from ccpi.viewer.CILViewerBase import CILViewerBase
 
@@ -473,7 +472,6 @@ class CILViewer(CILViewerBase):
 
         self.iren.Initialize()
 
-
     def getCamera(self):
         '''returns the active camera'''
         return self.ren.GetActiveCamera()
@@ -539,7 +537,6 @@ class CILViewer(CILViewerBase):
     def addActor(self, actor):
         '''Adds an actor to the render'''
         return self.showActor(0, actor)
-
 
     def setInput3DData(self, imageData):
         self.img3D = imageData
@@ -903,7 +900,6 @@ class CILViewer(CILViewerBase):
                                                                        self.maximum_opacity)
 
         return colors, opacity
-
 
     def getMappingArray(self, color_num, method):
         '''

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -741,7 +741,7 @@ class CILViewer(CILViewerBase):
             whether to immediately update the pipeline with this new
             setting
         '''
-        go_min, go_max = self.getVolumeMapRange((min, max), 'gradient')
+        go_min, go_max = self.getImageMapRange((min, max), 'gradient')
         self.setGradientOpacityRange(go_min, go_max, update_pipeline)
 
     def setScalarOpacityPercentiles(self, min, max, update_pipeline=True):
@@ -751,7 +751,7 @@ class CILViewer(CILViewerBase):
             opacity will be mapped to if setVolumeRenderOpacityMethod
             has been set to 'scalar'.
         '''
-        so_min, so_max = self.getVolumeMapRange((min, max), 'scalar')
+        so_min, so_max = self.getImageMapRange((min, max), 'scalar')
         self.setScalarOpacityRange(so_min, so_max, update_pipeline)
 
     def setVolumeColorPercentiles(self, min, max, update_pipeline=True):
@@ -759,7 +759,7 @@ class CILViewer(CILViewerBase):
         min, max: int, default: (85., 95.)
             the percentiles on the image values upon which the colours will be mapped to
         '''
-        cmin, cmax = self.getVolumeMapRange((min, max), 'scalar')
+        cmin, cmax = self.getImageMapRange((min, max), 'scalar')
         self.setVolumeColorRange(cmin, cmax, update_pipeline)
 
     def setGradientOpacityRange(self, min, max, update_pipeline=True):

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -16,65 +16,14 @@
 
 import vtk
 import numpy
-import os
-import glob, re
 
 from ccpi.viewer.utils import Converter
-from ccpi.viewer.utils.io import SaveRenderToPNG
 
-SLICE_ORIENTATION_XY = 2  # Z
-SLICE_ORIENTATION_XZ = 1  # Y
-SLICE_ORIENTATION_YZ = 0  # X
+from ccpi.viewer.CILViewerBase import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
+                                     LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
+                                     SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
 
-CONTROL_KEY = 8
-SHIFT_KEY = 4
-ALT_KEY = -128
-
-SLICE_ACTOR = 'slice_actor'
-OVERLAY_ACTOR = 'overlay_actor'
-HISTOGRAM_ACTOR = 'histogram_actor'
-HELP_ACTOR = 'help_actor'
-CURSOR_ACTOR = 'cursor_actor'
-CROSSHAIR_ACTOR = 'crosshair_actor'
-LINEPLOT_ACTOR = 'lineplot_actor'
-WIPE_ACTOR = 'wipe_actor'
-
-
-class ViewerEventManager(object):
-
-    def __init__(self):
-        # If all values are false it signifies no event
-        self.events = {
-            "PICK_EVENT": False,  # left  mouse
-            "WINDOW_LEVEL_EVENT": False,  # alt + right mouse + move
-            "ZOOM_EVENT": False,  # shift + right mouse + move
-            "PAN_EVENT": False,  # ctrl + right mouse + move
-            "CREATE_ROI_EVENT": False,  # ctrl + left mouse
-            "DELETE_ROI_EVENT": False,  # alt + left mouse
-            "SHOW_LINE_PROFILE_EVENT": False,  # l
-            "UPDATE_WINDOW_LEVEL_UNDER_CURSOR": False,  # Mouse move + w
-            "RECTILINEAR_WIPE": False  # activated by key 2, updates by mouse move
-        }
-
-    def __str__(self):
-        return str(self.events)
-
-    def On(self, event):
-        self.events[event] = True
-
-    def Off(self, event):
-        self.events[event] = False
-
-    def setAllInactive(self):
-        self.events = {x: False for x in self.events}
-
-    def isActive(self, event):
-        return self.events[event]
-
-    def isAllInactive(self):
-        """Returns True if all events are inactive"""
-        return all(not x for x in self.events.values())
-
+from ccpi.viewer.CILViewerBase import CILViewerBase
 
 class CILInteractorStyle(vtk.vtkInteractorStyle):
 
@@ -422,7 +371,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
     def AutoWindowLevel(self):
         # reset color/window
         cmin, cmax = self._viewer.ia.GetAutoRange()
-        window, level = self.getSliceWindowLevelFromRange(cmin, cmax)
+        window, level = self._viewer.getSliceWindowLevelFromRange(cmin, cmax)
 
         self.SetInitialLevel(level)
         self.SetInitialWindow(window)
@@ -926,7 +875,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
                 # reset color/window
                 cmin, cmax = self._viewer.iacursor.GetAutoRange()
 
-                window, level = self.getSliceWindowLevelFromRange(cmin, cmax)
+                window, level = self._viewer.getSliceWindowLevelFromRange(cmin, cmax)
 
                 self.SetInitialLevel(level)
                 self.SetInitialWindow(window)
@@ -1134,65 +1083,34 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
 ###############################################################################
 
 
-class CILViewer2D():
+class CILViewer2D(CILViewerBase):
     '''Simple Interactive Viewer based on VTK classes'''
     # visualisation modes
     IMAGE_WITH_OVERLAY = 0
     RECTILINEAR_WIPE = 1
 
     def __init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True):
-        '''creates the rendering pipeline'''
-        # create a rendering window and renderer
-        if ren == None:
-            self.ren = vtk.vtkRenderer()
-        else:
-            self.ren = ren
-        if renWin == None:
-            self.renWin = vtk.vtkRenderWindow()
-        else:
-            self.renWin = renWin
-        if iren == None:
-            self.iren = vtk.vtkRenderWindowInteractor()
-        else:
-            self.iren = iren
-        # holder for list of actors
-        self.actors = {}
-        self.debug = debug
-
-        self.renWin.SetSize(dimx, dimy)
-        self.renWin.AddRenderer(self.ren)
-
+        CILViewerBase.__init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True)
+        
         self.style = CILInteractorStyle(self)
-        self.style.debug = debug
-
         self.iren.SetInteractorStyle(self.style)
         self.iren.SetRenderWindow(self.renWin)
         self.iren.Initialize()
-        self.ren.SetBackground(.1, .2, .4)
 
+        self.debug = debug
+        self.style.debug = debug
+        
         self.camera = vtk.vtkCamera()
         self.camera.ParallelProjectionOn()
         self.flipCameraPosition = False
         self.ren.SetActiveCamera(self.camera)
 
-        # data (input 1)
-        self.img3D = None
-        self.slicenos = [0, 0, 0]
-        self.sliceOrientation = SLICE_ORIENTATION_XY
         self.axes_initialised = False
+        
         #Actors
-        self.voi = vtk.vtkExtractVOI()
-        self.ia = vtk.vtkImageHistogramStatistics()
         self.iacursor = vtk.vtkImageHistogramStatistics()
         self.voicursor = vtk.vtkExtractVOI()
         #self.sliceActorNo = 0
-
-        imageSlice = vtk.vtkImageSlice()
-        imageSliceMapper = vtk.vtkImageSliceMapper()
-        imageSlice.SetMapper(imageSliceMapper)
-        imageSlice.GetProperty().SetInterpolationTypeToNearest()
-        self.imageSlice = imageSlice
-        self.imageSliceMapper = imageSliceMapper
 
         # input 2
         self.image2 = None
@@ -1202,19 +1120,7 @@ class CILViewer2D():
         self.imageSlice2.SetMapper(self.imageSliceMapper2)
 
         # Help text
-        self.helpActor = vtk.vtkActor2D()
-        self.helpActor.GetPositionCoordinate().SetCoordinateSystemToNormalizedDisplay()
-        self.helpActor.GetPositionCoordinate().SetValue(0.1, 0.5)
-        self.helpActor.VisibilityOff()
-        # self.ren.AddActor(self.helpActor)
         self.AddActor(self.helpActor, HELP_ACTOR)
-
-        #initial Window/Level
-        self.InitialLevel = 0
-        self.InitialWindow = 0
-
-        #ViewerEvent
-        self.event = ViewerEventManager()
 
         # ROI Widget
         self.ROIWidget = vtk.vtkBoxWidget()
@@ -1280,15 +1186,6 @@ class CILViewer2D():
         self.firstHistogram = 0
         self.roiIA = vtk.vtkImageAccumulate()
         self.roiVOI = vtk.vtkExtractVOI()
-        self.histogramPlotActor = vtk.vtkXYPlotActor()
-        self.histogramPlotActor.ExchangeAxesOff()
-        self.histogramPlotActor.SetXLabelFormat("%g")
-        self.histogramPlotActor.SetXLabelFormat("%g")
-        self.histogramPlotActor.SetAdjustXLabels(3)
-        self.histogramPlotActor.SetXTitle("Level")
-        self.histogramPlotActor.SetYTitle("N")
-        self.histogramPlotActor.SetXValuesToValue()
-        self.histogramPlotActor.SetPlotColor(0, (0, 1, 1))
         self.histogramPlotActor.SetPosition2(0.6, 0.6)
         self.histogramPlotActor.SetPosition(0.4, 0.4)
 
@@ -1369,12 +1266,6 @@ class CILViewer2D():
     def log(self, msg):
         if self.debug:
             print(msg)
-
-    def getInteractor(self):
-        return self.iren
-
-    def getRenderer(self):
-        return self.ren
 
     def setInput3DData(self, imageData):
         '''alias of setInputData, kept for backward compatibility'''
@@ -1464,7 +1355,7 @@ class CILViewer2D():
         return extent
 
     def updateImageWithOverlayPipeline(self, resetcamera=False):
-        extent = self.updateMainVOI()
+        self.updateMainVOI()
         self.ia.Update()
         self.imageSliceMapper.SetOrientation(self.sliceOrientation)
         self.imageSlice.Update()
@@ -1493,9 +1384,9 @@ class CILViewer2D():
                 # When we are viewing the Y direction, the axis goes into the page
                 # so we have to swap which end of the axis the tracer is placed so
                 # that it isn't in the shadow of the slice.
-                if self.GetSliceOrientation() == SLICE_ORIENTATION_XZ:
-                    slice_coords[self.GetSliceOrientation()] = self.img3D.GetDimensions()[SLICE_ORIENTATION_XZ] - 1
-                self.imageTracer.SetProjectionPosition(self.style.image2world(slice_coords)[self.GetSliceOrientation()])
+                if self.getSliceOrientation() == SLICE_ORIENTATION_XZ:
+                    slice_coords[self.getSliceOrientation()] = self.img3D.GetDimensions()[SLICE_ORIENTATION_XZ] - 1
+                self.imageTracer.SetProjectionPosition(self.style.image2world(slice_coords)[self.getSliceOrientation()])
             else:
                 print("self.img3D None")
         except Exception as ge:
@@ -1608,7 +1499,7 @@ class CILViewer2D():
 
         self.imageSlice.Update()
 
-        self.imageTracer.SetProjectionPosition(self.style.image2world([0, 0, 0])[self.GetSliceOrientation()])
+        self.imageTracer.SetProjectionPosition(self.style.image2world([0, 0, 0])[self.getSliceOrientation()])
 
         self.AddActor(self.imageSlice, SLICE_ACTOR)
 
@@ -1663,7 +1554,7 @@ class CILViewer2D():
         for i in range(len(self.slicenos)):
             self.slicenos[i] = round((extent1[i * 2 + 1] + extent1[i * 2]) / 2)
         active_slice_num = self.getActiveSlice()
-        orient = self.GetSliceOrientation()
+        orient = self.getSliceOrientation()
         extent1[orient] = active_slice_num
         extent1[orient + 1] = active_slice_num
         extent2 = extent1[:]
@@ -1727,25 +1618,11 @@ class CILViewer2D():
 
     ############### Handle events are moved to the interactor style
 
-    def GetRenderWindow(self):
-        return self.renWin
-
-    def startRenderLoop(self):
-        self.iren.Start()
-
     def setSliceOrientation(self, axis):
         if axis in ['x', 'y', 'z']:
             self.getInteractor().SetKeyCode(axis)
             self.style.OnKeyPress(self.getInteractor(), "KeyPressEvent")
 
-    def GetSliceOrientation(self):
-        return self.sliceOrientation
-
-    def setActiveSlice(self, sliceno):
-        self.slicenos[self.GetSliceOrientation()] = sliceno
-
-    def getActiveSlice(self):
-        return self.slicenos[self.GetSliceOrientation()]
 
     def setVisualisationDownsampling(self, value):
         self.visualisation_downsampling = value
@@ -1794,10 +1671,10 @@ class CILViewer2D():
                     data = list(data)
                     slice_coord = [0, 0, 0]
                     axis_length = [0, 0, 0]
-                    slice_coord[self.GetSliceOrientation()] = data[0]
-                    axis_length[self.GetSliceOrientation()] = data[1] + 1
-                    slice_coord = self.style.image2world(slice_coord)[self.GetSliceOrientation()]
-                    axis_length = self.style.image2world(axis_length)[self.GetSliceOrientation()] - 1
+                    slice_coord[self.getSliceOrientation()] = data[0]
+                    axis_length[self.getSliceOrientation()] = data[1] + 1
+                    slice_coord = self.style.image2world(slice_coord)[self.getSliceOrientation()]
+                    axis_length = self.style.image2world(axis_length)[self.getSliceOrientation()] - 1
                     data = (round(slice_coord), round(axis_length))
                 text = "Slice %d/%d" % data
 
@@ -1826,37 +1703,14 @@ class CILViewer2D():
 
         return text
 
-    def saveRender(self, filename, renWin=None):
-        '''Save the render window to PNG file'''
-        # screenshot code:
 
-        if renWin == None:
-            renWin = self.renWin
-        SaveRenderToPNG(self.renWin, filename)
 
-    def validateValue(self, value, axis):
-        dims = self.img3D.GetDimensions()
-        max_slice = [x - 1 for x in dims]
-
-        axis_int = {'x': 0, 'y': 1, 'z': 2}
-
-        if axis in axis_int.keys():
-            i = axis_int[axis]
-        else:
-            raise KeyError
-
-        if value < 0:
-            return 0
-        if value > max_slice[i]:
-            return max_slice[i]
-        else:
-            return value
 
     def updateROIHistogram(self):
         self.log("Updating hist")
 
         extent = [0 for i in range(6)]
-        if self.GetSliceOrientation() == SLICE_ORIENTATION_XY:
+        if self.getSliceOrientation() == SLICE_ORIENTATION_XY:
             self.log("slice orientation : XY")
             extent[0] = self.validateValue(min(self.ROI[0][0], self.ROI[1][0]), 'x')
             extent[1] = self.validateValue(max(self.ROI[0][0], self.ROI[1][0]), 'x')
@@ -1865,7 +1719,7 @@ class CILViewer2D():
             extent[4] = self.getActiveSlice()
             extent[5] = self.getActiveSlice()
             # y = abs(roi[1][1] - roi[0][1])
-        elif self.GetSliceOrientation() == SLICE_ORIENTATION_XZ:
+        elif self.getSliceOrientation() == SLICE_ORIENTATION_XZ:
             self.log("slice orientation : XZ")
             extent[0] = self.validateValue(min(self.ROI[0][0], self.ROI[1][0]), 'x')
             extent[1] = self.validateValue(max(self.ROI[0][0], self.ROI[1][0]), 'x')
@@ -1875,7 +1729,7 @@ class CILViewer2D():
             # y = abs(roi[1][2] - roi[0][2])
             extent[2] = self.getActiveSlice()
             extent[3] = self.getActiveSlice()
-        elif self.GetSliceOrientation() == SLICE_ORIENTATION_YZ:
+        elif self.getSliceOrientation() == SLICE_ORIENTATION_YZ:
             self.log("slice orientation : YZ")
             extent[2] = self.validateValue(min(self.ROI[0][1], self.ROI[1][1]), 'y')
             extent[3] = self.validateValue(max(self.ROI[0][1], self.ROI[1][1]), 'y')
@@ -1910,24 +1764,6 @@ class CILViewer2D():
         self.histogramPlotActor.SetXRange(irange[0], irange[1])
         self.histogramPlotActor.SetYRange(self.roiIA.GetOutput().GetScalarRange())
 
-    def setColorWindowLevel(self, window, level):
-        self.imageSlice.GetProperty().SetColorLevel(level)
-        self.imageSlice.GetProperty().SetColorWindow(window)
-        self.imageSlice.Update()
-        self.ren.Render()
-        self.renWin.Render()
-
-    def setColorWindow(self, window):
-        self.imageSlice.GetProperty().SetColorWindow(window)
-        self.imageSlice.Update()
-        self.ren.Render()
-        self.renWin.Render()
-
-    def setColorLevel(self, level):
-        self.imageSlice.GetProperty().SetColorLevel(level)
-        self.imageSlice.Update()
-        self.ren.Render()
-        self.renWin.Render()
 
     def updateLinePlot(self, imagecoordinate, display):
 
@@ -1938,7 +1774,7 @@ class CILViewer2D():
 
         if display:
             #extract profile along X
-            if self.GetSliceOrientation() == SLICE_ORIENTATION_XY:
+            if self.getSliceOrientation() == SLICE_ORIENTATION_XY:
                 self.log("slice orientation : XY")
                 extent_y[0] = imagecoordinate[0]
                 extent_y[1] = imagecoordinate[0]
@@ -1955,7 +1791,7 @@ class CILViewer2D():
                 self.linePlotActor.SetDataObjectXComponent(1, 1)
 
                 #y = abs(roi[1][1] - roi[0][1])
-            elif self.GetSliceOrientation() == SLICE_ORIENTATION_XZ:
+            elif self.getSliceOrientation() == SLICE_ORIENTATION_XZ:
                 self.log("slice orientation : XZ")
                 extent_y[0] = imagecoordinate[0]
                 extent_y[1] = imagecoordinate[0]
@@ -1970,7 +1806,7 @@ class CILViewer2D():
                 self.linePlotActor.SetDataObjectXComponent(0, 0)
                 self.linePlotActor.SetDataObjectXComponent(1, 2)
 
-            elif self.GetSliceOrientation() == SLICE_ORIENTATION_YZ:
+            elif self.getSliceOrientation() == SLICE_ORIENTATION_YZ:
                 self.log("slice orientation : YZ")
                 extent_y[2] = imagecoordinate[1]
                 extent_y[3] = imagecoordinate[1]
@@ -2046,19 +1882,6 @@ class CILViewer2D():
 
             self.renWin.Render()
 
-    def getColourWindow(self):
-        return self.imageSlice.GetProperty().GetColorWindow()
-
-    def getColourLevel(self):
-        return self.imageSlice.GetProperty().GetColorLevel()
-
-    def getSliceWindowLevelFromRange(self, cmin, cmax):
-        # set the level to the average between the percentiles
-        level = (cmin + cmax) / 2
-        # accommodates all values between the level an the percentiles
-        window = cmax - cmin
-
-        return window, level
 
     def AddActor(self, actor, name=None):
         '''print("ADDING ACTOR", name)
@@ -2116,17 +1939,3 @@ class CILViewer2D():
         elif self.vis_mode == CILViewer2D.RECTILINEAR_WIPE:
             # rectilinear wipe visualises 2 images in the same pipeline
             pass
-
-    def getSliceMapRange(self, percentiles):
-        ia = vtk.vtkImageHistogramStatistics()
-        ia.SetInputData(self.img3D)
-        ia.SetAutoRangePercentiles(*percentiles)
-        ia.Update()
-        min, max = ia.GetAutoRange()
-        return min, max
-
-    def getSliceColorWindow(self):
-        return self.imageSlice.GetProperty().GetColorWindow()
-
-    def getSliceColorLevel(self):
-        return self.imageSlice.GetProperty().GetColorLevel()

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -14,16 +14,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import vtk
 import numpy
-
-from ccpi.viewer.utils import Converter
-
-from ccpi.viewer.CILViewerBase import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
-                                       LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
-                                       SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
-
+import vtk
+from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR,
+                         HELP_ACTOR, HISTOGRAM_ACTOR, LINEPLOT_ACTOR,
+                         OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR,
+                         SLICE_ORIENTATION_XY, SLICE_ORIENTATION_XZ,
+                         SLICE_ORIENTATION_YZ)
 from ccpi.viewer.CILViewerBase import CILViewerBase
+from ccpi.viewer.utils import Converter
 
 
 class CILInteractorStyle(vtk.vtkInteractorStyle):
@@ -1093,10 +1092,7 @@ class CILViewer2D(CILViewerBase):
     def __init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True):
         CILViewerBase.__init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True)
 
-        self.style = CILInteractorStyle(self)
-        self.iren.SetInteractorStyle(self.style)
-        self.iren.SetRenderWindow(self.renWin)
-        self.iren.Initialize()
+        self.setInteractorStyle(CILInteractorStyle(self))
 
         self.debug = debug
         self.style.debug = debug

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -20,10 +20,11 @@ import numpy
 from ccpi.viewer.utils import Converter
 
 from ccpi.viewer.CILViewerBase import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
-                                     LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
-                                     SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
+                                       LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
+                                       SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
 
 from ccpi.viewer.CILViewerBase import CILViewerBase
+
 
 class CILInteractorStyle(vtk.vtkInteractorStyle):
 
@@ -1091,7 +1092,7 @@ class CILViewer2D(CILViewerBase):
 
     def __init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True):
         CILViewerBase.__init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True)
-        
+
         self.style = CILInteractorStyle(self)
         self.iren.SetInteractorStyle(self.style)
         self.iren.SetRenderWindow(self.renWin)
@@ -1099,14 +1100,14 @@ class CILViewer2D(CILViewerBase):
 
         self.debug = debug
         self.style.debug = debug
-        
+
         self.camera = vtk.vtkCamera()
         self.camera.ParallelProjectionOn()
         self.flipCameraPosition = False
         self.ren.SetActiveCamera(self.camera)
 
         self.axes_initialised = False
-        
+
         #Actors
         self.iacursor = vtk.vtkImageHistogramStatistics()
         self.voicursor = vtk.vtkExtractVOI()
@@ -1623,7 +1624,6 @@ class CILViewer2D(CILViewerBase):
             self.getInteractor().SetKeyCode(axis)
             self.style.OnKeyPress(self.getInteractor(), "KeyPressEvent")
 
-
     def setVisualisationDownsampling(self, value):
         self.visualisation_downsampling = value
         if value != [1, 1, 1]:
@@ -1703,9 +1703,6 @@ class CILViewer2D(CILViewerBase):
 
         return text
 
-
-
-
     def updateROIHistogram(self):
         self.log("Updating hist")
 
@@ -1763,7 +1760,6 @@ class CILViewer2D(CILViewerBase):
         self.histogramPlotActor.AddDataSetInputConnection(self.roiIA.GetOutputPort())
         self.histogramPlotActor.SetXRange(irange[0], irange[1])
         self.histogramPlotActor.SetYRange(self.roiIA.GetOutput().GetScalarRange())
-
 
     def updateLinePlot(self, imagecoordinate, display):
 
@@ -1881,7 +1877,6 @@ class CILViewer2D(CILViewerBase):
             self.crosshairsActor.VisibilityOff()
 
             self.renWin.Render()
-
 
     def AddActor(self, actor, name=None):
         '''print("ADDING ACTOR", name)

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -16,11 +16,9 @@
 
 import numpy
 import vtk
-from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR,
-                         HELP_ACTOR, HISTOGRAM_ACTOR, LINEPLOT_ACTOR,
-                         OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR,
-                         SLICE_ORIENTATION_XY, SLICE_ORIENTATION_XZ,
-                         SLICE_ORIENTATION_YZ)
+from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
+                         LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
+                         SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
 from ccpi.viewer.CILViewerBase import CILViewerBase
 from ccpi.viewer.utils import Converter
 

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -56,7 +56,6 @@ class ViewerEventManager(object):
         return all(not x for x in self.events.values())
 
 class CILViewerBase():
-    '''Simple 3D Viewer based on VTK classes'''
 
     def __init__(self, dimx=600, dimy=600, renWin=None, iren=None, ren=None, debug=False):
         # Handle arguments:

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -201,7 +201,7 @@ class CILViewerBase():
         min, max = ia.GetAutoRange()
         return min, max
 
-    def getImageMapFullRange(self, method="scalar"):
+    def getImageMapWholeRange(self, method="scalar"):
         '''
         Parameters
         -----------

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -1,9 +1,7 @@
 import vtk
-from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR,
-                         HELP_ACTOR, HISTOGRAM_ACTOR, LINEPLOT_ACTOR,
-                         OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR,
-                         SLICE_ORIENTATION_XY, SLICE_ORIENTATION_XZ,
-                         SLICE_ORIENTATION_YZ)
+from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR, HELP_ACTOR, HISTOGRAM_ACTOR,
+                         LINEPLOT_ACTOR, OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR, SLICE_ORIENTATION_XY,
+                         SLICE_ORIENTATION_XZ, SLICE_ORIENTATION_YZ)
 from ccpi.viewer.utils.io import SaveRenderToPNG
 
 

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -47,7 +47,7 @@ class CILViewerBase():
 
     When making a subclass, the following must be set in the __init__:
 
-    SetInteractorStyle(style)
+    self.setInteractorStyle(style)
 
     '''
 

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -1,22 +1,10 @@
 import vtk
+from ccpi.viewer import (ALT_KEY, CONTROL_KEY, CROSSHAIR_ACTOR, CURSOR_ACTOR,
+                         HELP_ACTOR, HISTOGRAM_ACTOR, LINEPLOT_ACTOR,
+                         OVERLAY_ACTOR, SHIFT_KEY, SLICE_ACTOR,
+                         SLICE_ORIENTATION_XY, SLICE_ORIENTATION_XZ,
+                         SLICE_ORIENTATION_YZ)
 from ccpi.viewer.utils.io import SaveRenderToPNG
-
-SLICE_ORIENTATION_XY = 2  # Z
-SLICE_ORIENTATION_XZ = 1  # Y
-SLICE_ORIENTATION_YZ = 0  # X
-
-CONTROL_KEY = 8
-SHIFT_KEY = 4
-ALT_KEY = -128
-
-SLICE_ACTOR = 'slice_actor'
-OVERLAY_ACTOR = 'overlay_actor'
-HISTOGRAM_ACTOR = 'histogram_actor'
-HELP_ACTOR = 'help_actor'
-CURSOR_ACTOR = 'cursor_actor'
-CROSSHAIR_ACTOR = 'crosshair_actor'
-LINEPLOT_ACTOR = 'lineplot_actor'
-WIPE_ACTOR = 'wipe_actor'
 
 
 class ViewerEventManager(object):
@@ -56,6 +44,14 @@ class ViewerEventManager(object):
 
 
 class CILViewerBase():
+    '''
+    Base Class for CILViewers.
+
+    When making a subclass, the following must be set in the __init__:
+
+    SetInteractorStyle(style)
+
+    '''
 
     def __init__(self, dimx=600, dimy=600, renWin=None, iren=None, ren=None, debug=False):
         # Handle arguments:
@@ -76,6 +72,8 @@ class CILViewerBase():
             self.iren = iren
         else:
             self.iren = vtk.vtkRenderWindowInteractor()
+
+        self.iren.SetRenderWindow(self.renWin)
 
         self.ren.SetBackground(.1, .2, .4)
 
@@ -131,6 +129,11 @@ class CILViewerBase():
         self.histogramPlotActor.SetXValuesToValue()
         self.histogramPlotActor.SetPlotColor(0, (0, 1, 1))
 
+    def setInteractorStyle(self, style):
+        self.style = style
+        self.iren.SetInteractorStyle(self.style)
+        self.iren.Initialize()
+
     def getInteractor(self):
         return self.iren
 
@@ -140,6 +143,10 @@ class CILViewerBase():
     def getRenderWindow(self):
         '''returns the render window'''
         return self.renWin
+
+    def getCamera(self):
+        '''returns the active camera'''
+        return self.ren.GetActiveCamera()
 
     def getSliceOrientation(self):
         return self.sliceOrientation
@@ -196,16 +203,18 @@ class CILViewerBase():
         min, max = ia.GetAutoRange()
         return min, max
 
-    def getVolumeRange(self, method):
+    def getFullVolumeRange(self, method):
         '''
         Parameters
         -----------
         method: string : ['scalar', 'gradient']
-            'scalar' - returns full range of values in image
-            'gradient' - returns full range of values in image gradient
+            'scalar' - returns full range of values in the 3D image
+            'gradient' - returns full range of values in 3D image's gradient
         '''
 
-        return self.getVolumeMapRange((0, 100), method)
+        ia = self.getImageHistogramStatistics(method)
+
+        return ia.GetMinimum(), ia.GetMaximum()
 
     # Set interpolation on
     def setInterpolateOn(self):
@@ -219,6 +228,9 @@ class CILViewerBase():
         self.renWin.Render()
 
     def setSliceColorWindowLevel(self, window, level):
+        '''
+        Set the window and level for the 2D slice of the 3D image.
+        '''
         # Level is the average of min and max, and the window is the difference.
         self.imageSlice.GetProperty().SetColorLevel(level)
         self.imageSlice.GetProperty().SetColorWindow(window)
@@ -232,18 +244,29 @@ class CILViewerBase():
         self.setSliceColorWindowLevel(min_val, max_val)
 
     def setSliceColorWindow(self, window):
+        '''
+        Set the window for the 2D slice of the 3D image.
+        '''
         self.imageSlice.GetProperty().SetColorWindow(window)
         self.imageSlice.Update()
         self.ren.Render()
         self.renWin.Render()
 
     def setSliceColorLevel(self, level):
+        '''
+        Set the level for the 2D slice of the 3D image.
+        '''
         self.imageSlice.GetProperty().SetColorLevel(level)
         self.imageSlice.Update()
         self.ren.Render()
         self.renWin.Render()
 
     def getSliceMapRange(self, percentiles):
+        '''
+        uses percentiles to generate min and max values in
+        the 2D slice of the 3D image, for which
+        the colormap is displayed.
+        '''
         ia = vtk.vtkImageHistogramStatistics()
         ia.SetInputData(self.img3D)
         ia.SetAutoRangePercentiles(*percentiles)
@@ -253,9 +276,7 @@ class CILViewerBase():
 
     def saveRender(self, filename, renWin=None):
         '''Save the render window to PNG file'''
-        # screenshot code:
-
-        if renWin == None:
+        if renWin is None:
             renWin = self.renWin
         SaveRenderToPNG(self.renWin, filename)
 
@@ -276,3 +297,6 @@ class CILViewerBase():
             return max_slice[i]
         else:
             return value
+
+    def setInput3DData(self, imageData):
+        raise NotImplementedError("Implemented in the subclasses.")

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -1,0 +1,279 @@
+
+import vtk
+from ccpi.viewer.utils.io import SaveRenderToPNG
+
+SLICE_ORIENTATION_XY = 2  # Z
+SLICE_ORIENTATION_XZ = 1  # Y
+SLICE_ORIENTATION_YZ = 0  # X
+
+CONTROL_KEY = 8
+SHIFT_KEY = 4
+ALT_KEY = -128
+
+SLICE_ACTOR = 'slice_actor'
+OVERLAY_ACTOR = 'overlay_actor'
+HISTOGRAM_ACTOR = 'histogram_actor'
+HELP_ACTOR = 'help_actor'
+CURSOR_ACTOR = 'cursor_actor'
+CROSSHAIR_ACTOR = 'crosshair_actor'
+LINEPLOT_ACTOR = 'lineplot_actor'
+WIPE_ACTOR = 'wipe_actor'
+
+
+class ViewerEventManager(object):
+
+    def __init__(self):
+        # If all values are false it signifies no event
+        self.events = {
+            "PICK_EVENT": False,  # left  mouse
+            "WINDOW_LEVEL_EVENT": False,  # alt + right mouse + move
+            "ZOOM_EVENT": False,  # shift + right mouse + move
+            "PAN_EVENT": False,  # ctrl + right mouse + move
+            "CREATE_ROI_EVENT": False,  # ctrl + left mouse
+            "DELETE_ROI_EVENT": False,  # alt + left mouse
+            "SHOW_LINE_PROFILE_EVENT": False,  # l
+            "UPDATE_WINDOW_LEVEL_UNDER_CURSOR": False,  # Mouse move + w
+            "RECTILINEAR_WIPE": False  # activated by key 2, updates by mouse move
+        }
+
+    def __str__(self):
+        return str(self.events)
+
+    def On(self, event):
+        self.events[event] = True
+
+    def Off(self, event):
+        self.events[event] = False
+
+    def setAllInactive(self):
+        self.events = {x: False for x in self.events}
+
+    def isActive(self, event):
+        return self.events[event]
+
+    def isAllInactive(self):
+        """Returns True if all events are inactive"""
+        return all(not x for x in self.events.values())
+
+class CILViewerBase():
+    '''Simple 3D Viewer based on VTK classes'''
+
+    def __init__(self, dimx=600, dimy=600, renWin=None, iren=None, ren=None, debug=False):
+        # Handle arguments:
+        # create a renderer
+        if ren is None:
+            ren = vtk.vtkRenderer()
+        self.ren = ren
+
+        # create a rendering window
+        if renWin is None:
+            renWin = vtk.vtkRenderWindow()
+
+        renWin.SetSize(dimx, dimy)
+        renWin.AddRenderer(self.ren)
+        self.renWin = renWin
+
+        if iren is not None:
+            self.iren = iren
+        else:
+            self.iren = vtk.vtkRenderWindowInteractor()
+
+        self.ren.SetBackground(.1, .2, .4)
+
+        # img 3D as slice
+        self.img3D = None
+        self.slicenos = [0, 0, 0]
+        self.sliceOrientation = SLICE_ORIENTATION_XY
+
+        imageSlice = vtk.vtkImageSlice()
+        imageSliceMapper = vtk.vtkImageSliceMapper()
+        imageSlice.SetMapper(imageSliceMapper)
+        imageSlice.GetProperty().SetInterpolationTypeToNearest()
+        self.imageSlice = imageSlice
+        self.imageSliceMapper = imageSliceMapper
+
+        self.voi = vtk.vtkExtractVOI()
+        self.ia = vtk.vtkImageHistogramStatistics()
+        self.ia.SetAutoRangePercentiles(5.0, 95.)
+
+        self.helpActor = vtk.vtkActor2D()
+        self.helpActor.GetPositionCoordinate().SetCoordinateSystemToNormalizedDisplay()
+        self.helpActor.GetPositionCoordinate().SetValue(0.1, 0.5)
+        self.helpActor.VisibilityOff()
+
+        # axis orientation widget
+        om = vtk.vtkAxesActor()
+        ori = vtk.vtkOrientationMarkerWidget()
+        ori.SetOutlineColor(0.9300, 0.5700, 0.1300)
+        ori.SetInteractor(self.iren)
+        ori.SetOrientationMarker(om)
+        ori.SetViewport(0.0, 0.0, 0.4, 0.4)
+        ori.SetEnabled(1)
+        ori.InteractiveOff()
+        self.orientation_marker = ori
+
+        # holder for list of actors
+        self.actors = {}
+
+        #initial Window/Level
+        self.InitialLevel = 0
+        self.InitialWindow = 0
+
+        #ViewerEvent
+        self.event = ViewerEventManager()
+
+        self.histogramPlotActor = vtk.vtkXYPlotActor()
+        self.histogramPlotActor.ExchangeAxesOff()
+        self.histogramPlotActor.SetXLabelFormat("%g")
+        self.histogramPlotActor.SetXLabelFormat("%g")
+        self.histogramPlotActor.SetAdjustXLabels(3)
+        self.histogramPlotActor.SetXTitle("Level")
+        self.histogramPlotActor.SetYTitle("N")
+        self.histogramPlotActor.SetXValuesToValue()
+        self.histogramPlotActor.SetPlotColor(0, (0, 1, 1))
+
+    def getInteractor(self):
+        return self.iren
+
+    def getRenderer(self):
+        return self.ren
+    
+    def getRenderWindow(self):
+        '''returns the render window'''
+        return self.renWin
+
+    def getSliceOrientation(self):
+        return self.sliceOrientation
+
+    def setActiveSlice(self, sliceno):
+        self.slicenos[self.getSliceOrientation()] = sliceno
+
+    def getActiveSlice(self):
+        return self.slicenos[self.getSliceOrientation()]
+
+    def getSliceColorWindow(self):
+        return self.imageSlice.GetProperty().GetColorWindow()
+
+    def getSliceColorLevel(self):
+        return self.imageSlice.GetProperty().GetColorLevel()
+
+    def getSliceWindowLevelFromRange(self, cmin, cmax):
+        # set the level to the average between the percentiles
+        level = (cmin + cmax) / 2
+        # accommodates all values between the level an the percentiles
+        window = cmax - cmin
+
+        return window, level
+
+    def startRenderLoop(self):
+        self.iren.Start()
+
+    def getImageHistogramStatistics(self, method):
+        '''
+        returns histogram statistics for either the image
+        or gradient of the image depending on the method
+        '''
+        ia = vtk.vtkImageHistogramStatistics()
+        if method == 'scalar':
+            ia.SetInputData(self.img3D)
+        else:
+            grad = vtk.vtkImageGradientMagnitude()
+            grad.SetInputData(self.img3D)
+            grad.SetDimensionality(3)
+            grad.Update()
+            ia.SetInputData(grad.GetOutput())
+        ia.Update()
+        return ia
+
+    def getVolumeMapRange(self, percentiles, method):
+        '''
+        uses percentiles to generate min and max values in either
+        the image or image gradient (depending on method) for which
+        the colormap or opacity are displayed.
+        '''
+        ia = self.getImageHistogramStatistics(method)
+        ia.SetAutoRangePercentiles(*percentiles)
+        ia.Update()
+        min, max = ia.GetAutoRange()
+        return min, max
+
+    def getVolumeRange(self, method):
+        '''
+        Parameters
+        -----------
+        method: string : ['scalar', 'gradient']
+            'scalar' - returns full range of values in image
+            'gradient' - returns full range of values in image gradient
+        '''
+
+        return self.getVolumeMapRange((0, 100), method)
+
+    # Set interpolation on
+    def setInterpolateOn(self):
+        self.imageSlice.GetProperty().SetInterpolationTypeToLinear()
+        self.renWin.Render()
+
+    # Set interpolation off
+    def setInterpolateOff(self):
+        self.imageSlice.GetProperty()\
+            .SetInterpolationTypeToNearest()
+        self.renWin.Render()
+
+    def setSliceColorWindowLevel(self, window, level):
+        # Level is the average of min and max, and the window is the difference.
+        self.imageSlice.GetProperty().SetColorLevel(level)
+        self.imageSlice.GetProperty().SetColorWindow(window)
+        self.imageSlice.Update()
+        self.ren.Render()
+        self.renWin.Render()
+
+    def setSliceColorPercentiles(self, min_percentage, max_percentage):
+        #TODO: LATER: FIX THIS METHOD - IT DOESN'T WORK CORRECTLY
+        min_val, max_val = self.getVolumeMapRange((min_percentage, max_percentage), 'scalar')
+        self.setSliceColorWindowLevel(min_val, max_val)
+
+    def setSliceColorWindow(self, window):
+        self.imageSlice.GetProperty().SetColorWindow(window)
+        self.imageSlice.Update()
+        self.ren.Render()
+        self.renWin.Render()
+
+    def setSliceColorLevel(self, level):
+        self.imageSlice.GetProperty().SetColorLevel(level)
+        self.imageSlice.Update()
+        self.ren.Render()
+        self.renWin.Render()
+
+    def getSliceMapRange(self, percentiles):
+        ia = vtk.vtkImageHistogramStatistics()
+        ia.SetInputData(self.img3D)
+        ia.SetAutoRangePercentiles(*percentiles)
+        ia.Update()
+        min, max = ia.GetAutoRange()
+        return min, max
+
+    def saveRender(self, filename, renWin=None):
+        '''Save the render window to PNG file'''
+        # screenshot code:
+
+        if renWin == None:
+            renWin = self.renWin
+        SaveRenderToPNG(self.renWin, filename)
+
+    def validateValue(self, value, axis):
+        dims = self.img3D.GetDimensions()
+        max_slice = [x - 1 for x in dims]
+
+        axis_int = {'x': 0, 'y': 1, 'z': 2}
+
+        if axis in axis_int.keys():
+            i = axis_int[axis]
+        else:
+            raise KeyError
+
+        if value < 0:
+            return 0
+        if value > max_slice[i]:
+            return max_slice[i]
+        else:
+            return value

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -1,4 +1,3 @@
-
 import vtk
 from ccpi.viewer.utils.io import SaveRenderToPNG
 
@@ -54,6 +53,7 @@ class ViewerEventManager(object):
     def isAllInactive(self):
         """Returns True if all events are inactive"""
         return all(not x for x in self.events.values())
+
 
 class CILViewerBase():
 
@@ -136,7 +136,7 @@ class CILViewerBase():
 
     def getRenderer(self):
         return self.ren
-    
+
     def getRenderWindow(self):
         '''returns the render window'''
         return self.renWin

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -189,7 +189,7 @@ class CILViewerBase():
         ia.Update()
         return ia
 
-    def getImageMapRange(self, percentiles, method):
+    def getImageMapRange(self, percentiles, method="scalar"):
         '''
         uses percentiles to generate min and max values in either
         the image or image gradient (depending on method) for which
@@ -201,7 +201,7 @@ class CILViewerBase():
         min, max = ia.GetAutoRange()
         return min, max
 
-    def getFullImageRange(self, method):
+    def getImageMapFullRange(self, method="scalar"):
         '''
         Parameters
         -----------
@@ -259,14 +259,13 @@ class CILViewerBase():
         self.ren.Render()
         self.renWin.Render()
 
-    def getSliceMapRange(self, percentiles):
+    def getSliceMapRange(self, percentiles, method="scalar"):
         '''
         uses percentiles to generate min and max values in
         the 2D slice of the 3D image, for which
         the colormap is displayed.
         '''
-        ia = vtk.vtkImageHistogramStatistics()
-        ia.SetInputData(self.img3D)
+        ia = self.getImageHistogramStatistics(method)
         ia.SetAutoRangePercentiles(*percentiles)
         ia.Update()
         min, max = ia.GetAutoRange()

--- a/Wrappers/Python/ccpi/viewer/CILViewerBase.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewerBase.py
@@ -189,7 +189,7 @@ class CILViewerBase():
         ia.Update()
         return ia
 
-    def getVolumeMapRange(self, percentiles, method):
+    def getImageMapRange(self, percentiles, method):
         '''
         uses percentiles to generate min and max values in either
         the image or image gradient (depending on method) for which
@@ -201,7 +201,7 @@ class CILViewerBase():
         min, max = ia.GetAutoRange()
         return min, max
 
-    def getFullVolumeRange(self, method):
+    def getFullImageRange(self, method):
         '''
         Parameters
         -----------
@@ -238,7 +238,7 @@ class CILViewerBase():
 
     def setSliceColorPercentiles(self, min_percentage, max_percentage):
         #TODO: LATER: FIX THIS METHOD - IT DOESN'T WORK CORRECTLY
-        min_val, max_val = self.getVolumeMapRange((min_percentage, max_percentage), 'scalar')
+        min_val, max_val = self.getImageMapRange((min_percentage, max_percentage), 'scalar')
         self.setSliceColorWindowLevel(min_val, max_val)
 
     def setSliceColorWindow(self, window):

--- a/Wrappers/Python/ccpi/viewer/__init__.py
+++ b/Wrappers/Python/ccpi/viewer/__init__.py
@@ -1,3 +1,20 @@
+SLICE_ORIENTATION_XY = 2  # Z
+SLICE_ORIENTATION_XZ = 1  # Y
+SLICE_ORIENTATION_YZ = 0  # X
+
+CONTROL_KEY = 8
+SHIFT_KEY = 4
+ALT_KEY = -128
+
+SLICE_ACTOR = 'slice_actor'
+OVERLAY_ACTOR = 'overlay_actor'
+HISTOGRAM_ACTOR = 'histogram_actor'
+HELP_ACTOR = 'help_actor'
+CURSOR_ACTOR = 'cursor_actor'
+CROSSHAIR_ACTOR = 'crosshair_actor'
+LINEPLOT_ACTOR = 'lineplot_actor'
+WIPE_ACTOR = 'wipe_actor'
+
 from .CILViewer import CILViewer as viewer3D
 from .CILViewer2D import CILViewer2D as viewer2D
 from .CILViewer import CILInteractorStyle as istyle3D

--- a/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
+++ b/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
@@ -329,15 +329,12 @@ class TrameViewer:
         self.slice_window_sliders_are_detailed = show_detailed
 
     def change_slice_window_range(self, window: float, level: float):
-        if hasattr(self.cil_viewer, "setSliceColorWindowLevel"):
-            if self.slice_window_slider_is_percentage:
-                min_percentage = level - window / 2
-                max_percentage = window + level - window / 2
-                self.cil_viewer.setSliceColorPercentiles(min_percentage, max_percentage)
-            else:
-                self.cil_viewer.setSliceColorWindowLevel(window, level)
+        if hasattr(self, 'slice_window_slider_is_percentage') and self.slice_window_slider_is_percentage:
+            min_percentage = level - window / 2
+            max_percentage = window + level - window / 2
+            self.cil_viewer.setSliceColorPercentiles(min_percentage, max_percentage)
         else:
-            self.cil_viewer.setColorWindowLevel(window, level)
+            self.cil_viewer.setSliceColorWindowLevel(window, level)
         self.cil_viewer.updatePipeline()
         self.html_view.update()
 
@@ -355,15 +352,12 @@ class TrameViewer:
         self.html_view.update()
 
     def change_slice_level(self, new_level: float, current_window: float = None):
-        if hasattr(self.cil_viewer, "setSliceColorLevel"):
-            if self.slice_window_slider_is_percentage:
-                if current_window is None:
-                    current_window = new_level
-                self.cil_viewer.setSliceColorPercentiles(current_window, new_level)
-            else:
-                self.cil_viewer.setSliceColorLevel(level=new_level)
+        if hasattr(self, "slice_window_slider_is_percentage") and self.slice_window_slider_is_percentage:
+            if current_window is None:
+                current_window = new_level
+            self.cil_viewer.setSliceColorPercentiles(current_window, new_level)
         else:
-            self.cil_viewer.setColorLevel(level=new_level)
+            self.cil_viewer.setSliceColorLevel(level=new_level)
         self.cil_viewer.updatePipeline()
         self.html_view.update()
 

--- a/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
+++ b/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
@@ -267,7 +267,7 @@ class TrameViewer:
 
     def update_slice_data(self):
         self.slice_window_range_defaults = self.cil_viewer.getSliceMapRange((5., 95.))
-        self.cmin, self.cmax = self.cil_viewer.getVolumeMapRange((0., 100.), "scalar")
+        self.cmin, self.cmax = self.cil_viewer.getImageMapRange((0., 100.), "scalar")
         self.slice_level_default = self.cil_viewer.getSliceColorLevel()
         self.slice_window_default = self.cil_viewer.getSliceColorWindow()
 

--- a/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
+++ b/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
@@ -335,7 +335,8 @@ class TrameViewer:
         self.html_view.update()
 
     def change_slice_window(self, new_window: float, current_level: float = None):
-        if hasattr(self, "slice_window_slider_is_percentage") and self.slice_window_slider_is_percentage and current_level is None:
+        if hasattr(self, "slice_window_slider_is_percentage"
+                   ) and self.slice_window_slider_is_percentage and current_level is None:
             current_level = new_window
             self.cil_viewer.setSliceColorPercentiles(new_window, current_level)
         else:

--- a/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
+++ b/Wrappers/Python/ccpi/web_viewer/trame_viewer.py
@@ -266,12 +266,8 @@ class TrameViewer:
         )
 
     def update_slice_data(self):
-        if hasattr(self.cil_viewer, "getSliceMapRange"):
-            self.cmin, self.cmax = self.cil_viewer.getSliceMapRange((0., 100.))
-            self.slice_window_range_defaults = self.cil_viewer.getSliceMapRange((5., 95.))
-        else:
-            self.cmin, self.cmax = self.cil_viewer.getVolumeMapRange((0., 100.), "scalar")
-            self.slice_window_range_defaults = self.cil_viewer.getVolumeMapRange((5., 95.), "scalar")
+        self.slice_window_range_defaults = self.cil_viewer.getSliceMapRange((5., 95.))
+        self.cmin, self.cmax = self.cil_viewer.getVolumeMapRange((0., 100.), "scalar")
         self.slice_level_default = self.cil_viewer.getSliceColorLevel()
         self.slice_window_default = self.cil_viewer.getSliceColorWindow()
 
@@ -339,15 +335,11 @@ class TrameViewer:
         self.html_view.update()
 
     def change_slice_window(self, new_window: float, current_level: float = None):
-        if hasattr(self.cil_viewer, "setSliceColorWindow"):
-            if self.slice_window_slider_is_percentage:
-                if current_level is None:
-                    current_level = new_window
-                self.cil_viewer.setSliceColorPercentiles(new_window, current_level)
-            else:
-                self.cil_viewer.setSliceColorWindow(window=new_window)
+        if hasattr(self, "slice_window_slider_is_percentage") and self.slice_window_slider_is_percentage and current_level is None:
+            current_level = new_window
+            self.cil_viewer.setSliceColorPercentiles(new_window, current_level)
         else:
-            self.cil_viewer.setColorWindow(window=new_window)
+            self.cil_viewer.setSliceColorWindow(window=new_window)
         self.cil_viewer.updatePipeline()
         self.html_view.update()
 

--- a/Wrappers/Python/ccpi/web_viewer/trame_viewer3D.py
+++ b/Wrappers/Python/ccpi/web_viewer/trame_viewer3D.py
@@ -290,8 +290,8 @@ class TrameViewer3D(TrameViewer):
     def update_windowing_defaults(self, method="scalar"):
         self.update_slice_data()
         # Set cmin and cmax after set_slice_defaults because set_slice only uses scalar whereas we need to support gradient in 3D
-        self.cmin, self.cmax = self.cil_viewer.getVolumeMapRange((0., 100.), method)
-        self.windowing_defaults = self.cil_viewer.getVolumeMapRange((80., 99.), method)
+        self.cmin, self.cmax = self.cil_viewer.getImageMapRange((0., 100.), method)
+        self.windowing_defaults = self.cil_viewer.getImageMapRange((80., 99.), method)
         if hasattr(self, "windowing_range_slider") and self.windowing_range_slider is not None \
                 and hasattr(self, "color_slider") and self.color_slider is not None:
             self.windowing_range_slider = self.construct_windowing_slider()
@@ -374,7 +374,7 @@ class TrameViewer3D(TrameViewer):
         state["slice_visibility"] = True
         state["volume_visibility"] = True
         state["slice_detailed_sliders"] = False
-        state["slice_window_range"] = self.cil_viewer.getVolumeMapRange((5., 95.), "scalar")
+        state["slice_window_range"] = self.cil_viewer.getImageMapRange((5., 95.), "scalar")
         state["slice_window"] = self.cil_viewer.getSliceColorWindow()
         state["slice_level"] = self.cil_viewer.getSliceColorLevel()
         state["background_color"] = "cil_viewer_blue"

--- a/Wrappers/Python/examples/viewer2D-without-qt.py
+++ b/Wrappers/Python/examples/viewer2D-without-qt.py
@@ -1,8 +1,8 @@
 from ccpi.viewer import viewer2D
-from ccpi.viewer.utils import data_example
+from ccpi.viewer.utils import example_data
 
 v = viewer2D()
 # Load head data
-data = data_example.HEAD.get()
+data = example_data.HEAD.get()
 v.setInputData(data)
 v.startRenderLoop()

--- a/Wrappers/Python/examples/viewer3D-without-qt.py
+++ b/Wrappers/Python/examples/viewer3D-without-qt.py
@@ -1,8 +1,8 @@
 from ccpi.viewer import viewer3D
-from ccpi.viewer.utils import data_example
+from ccpi.viewer.utils import example_data
 
 v = viewer3D()
 # Load head data
-data = data_example.HEAD.get()
+data = example_data.HEAD.get()
 v.setInputData(data)
 v.startRenderLoop()

--- a/Wrappers/Python/setup.py
+++ b/Wrappers/Python/setup.py
@@ -36,7 +36,7 @@ def version2pep440(version):
     return v_pep440
 
 
-git_version_string = "23" #subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()[1:]
+git_version_string = "23"  #subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()[1:]
 
 if os.environ.get('CONDA_BUILD', 0) == '1':
     cwd = os.path.join(os.environ.get('RECIPE_DIR'), '..')

--- a/Wrappers/Python/setup.py
+++ b/Wrappers/Python/setup.py
@@ -36,7 +36,7 @@ def version2pep440(version):
     return v_pep440
 
 
-git_version_string = "23"  #subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()[1:]
+git_version_string = subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()[1:]
 
 if os.environ.get('CONDA_BUILD', 0) == '1':
     cwd = os.path.join(os.environ.get('RECIPE_DIR'), '..')

--- a/Wrappers/Python/setup.py
+++ b/Wrappers/Python/setup.py
@@ -36,7 +36,7 @@ def version2pep440(version):
     return v_pep440
 
 
-git_version_string = subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()[1:]
+git_version_string = "23" #subprocess.check_output('git describe', shell=True).decode("utf-8").rstrip()[1:]
 
 if os.environ.get('CONDA_BUILD', 0) == '1':
     cwd = os.path.join(os.environ.get('RECIPE_DIR'), '..')


### PR DESCRIPTION
- Adds base class with current common methods between 3D and 2D viewers.
- Later should modify more methods so they are common between the viewers. Could also add methods with NotImplementedError in base class, that are defined in the subclasses.
- In a separate PR will add a base class for the interactor style.

Addresses part of: #215 
Closes #274