### PR TITLE
Qt examples use head from example_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
 ## v22.x.x
+- Qt examples use example_data 
+- Updates in all classes to take into account the backward incompatible methods name changes (see below)
+- cilPlaneClipper: 
+  - change signature of creator, and defaults to empty list of items to be clipped on init
+  - renamed Get/SetInteractor->Get/SetInteractorStyle
 - Renamed all classes bearing name baseReader to ReaderInterface as they provide the interface not a abstract reader class.
-- Added TIFF resample and cropped readers
+- Added TIFF resample and cropped readers with unit tests
 - web_viewer:
   - added web viewer using trame for viewer3D and viewer2D
   - add entry point for running the web viewers

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -426,7 +426,7 @@ class CILViewer(CILViewerBase):
     '''Simple 3D Viewer based on VTK classes'''
 
     def __init__(self, dimx=600, dimy=600, renWin=None, iren=None, ren=None, debug=False):
-        CILViewerBase.__init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True)
+        CILViewerBase.__init__(self, dimx=dimx, dimy=dimy, ren=ren, renWin=renWin, iren=iren, debug=debug)
         '''creates the rendering pipeline'''
 
         self.setInteractorStyle(CILInteractorStyle(self))

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -1088,7 +1088,7 @@ class CILViewer2D(CILViewerBase):
     RECTILINEAR_WIPE = 1
 
     def __init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True):
-        CILViewerBase.__init__(self, dimx=600, dimy=600, ren=None, renWin=None, iren=None, debug=True)
+        CILViewerBase.__init__(self, dimx=dimx, dimy=dimy, ren=ren, renWin=renWin, iren=iren, debug=debug)
 
         self.setInteractorStyle(CILInteractorStyle(self))
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -1244,17 +1244,6 @@ class CILViewer2D(CILViewerBase):
         self.imageTracer.AutoCloseOn()
         self.imageTracer.AddObserver(vtk.vtkWidgetEvent.Select, self.style.OnTracerModifiedEvent, 1.0)
 
-        # axis orientation widget
-        om = vtk.vtkAxesActor()
-        ori = vtk.vtkOrientationMarkerWidget()
-        ori.SetOutlineColor(0.9300, 0.5700, 0.1300)
-        ori.SetInteractor(self.iren)
-        ori.SetOrientationMarker(om)
-        ori.SetViewport(0.0, 0.0, 0.4, 0.4)
-        ori.SetEnabled(1)
-        ori.InteractiveOff()
-        self.orientation_marker = ori
-
         self.__vis_mode = CILViewer2D.IMAGE_WITH_OVERLAY
         self.setVisualisationToImageWithOverlay()
 

--- a/Wrappers/Python/ccpi/viewer/QCILViewerWidget.py
+++ b/Wrappers/Python/ccpi/viewer/QCILViewerWidget.py
@@ -41,6 +41,7 @@ class QCILViewerWidget(QtWidgets.QFrame):
         else:
             self.ren = vtk.vtkRenderer()
         self.vtkWidget.GetRenderWindow().AddRenderer(self.ren)
+        # https://discourse.vtk.org/t/qvtkwidget-render-window-is-outside-main-qt-app-window/1539/8?u=edoardo_pasca
         self.iren = self.vtkWidget.GetRenderWindow().GetInteractor()
         try:
 

--- a/Wrappers/Python/ccpi/viewer/utils/visualisation_pipeline.py
+++ b/Wrappers/Python/ccpi/viewer/utils/visualisation_pipeline.py
@@ -172,29 +172,19 @@ class cilPlaneClipper(object):
                     interactor = self.Interactor
                     interactor.UpdatePipeline()
 
-                # print("Update Clipping Planes", self.DataListToClip)
-                # print("Clipping Event: ", event)
-
-                # print("Orientation", interactor.GetSliceOrientation())
-                # print("Interactor", interactor)
-
                 normal = [0, 0, 0]
                 origin = [0, 0, 0]
                 norm = 1
 
-                orientation = interactor.getSliceOrientation()
+                orientation = interactor.GetSliceOrientation()
 
                 spac = interactor.GetInputData().GetSpacing()
                 orig = interactor.GetInputData().GetOrigin()
                 slice_thickness = spac[orientation]
 
-                #print("Current active slice in image coords:", interactor.GetActiveSlice())
-
                 current_slice = [0, 0, 0]
                 current_slice[orientation] = interactor.getActiveSlice()
                 current_slice = interactor.image2world(current_slice)
-
-                #print("Current active slice in world coords: ", current_slice)
 
                 beta_up = 0.5 - 1e-9
                 beta_down = 0.5
@@ -216,7 +206,6 @@ class cilPlaneClipper(object):
                 origin_below = slice_below
 
                 for data_to_clip in self.DataListToClip.values():
-                    #print("On data: ", list(self.DataListToClip.keys())[list(self.DataListToClip.values()).index(data_to_clip)])
                     data_to_clip.SetPlaneOriginAbove(origin_above)
                     data_to_clip.SetPlaneNormalAbove(normal)
                     data_to_clip.SetPlaneOriginBelow(origin_below)

--- a/Wrappers/Python/ccpi/viewer/utils/visualisation_pipeline.py
+++ b/Wrappers/Python/ccpi/viewer/utils/visualisation_pipeline.py
@@ -123,9 +123,10 @@ class cilClipPolyDataBetweenPlanes(VTKPythonAlgorithmBase):
 
 class cilPlaneClipper(object):
 
-    def __init__(self, interactor, data_list_to_clip={}):
-        self.SetInteractor(interactor)
-        self.SetDataListToClip(data_list_to_clip)
+    def __init__(self):
+        # initilise with an empty dictionary of polydata to clip
+        list2clip = {}
+        self.SetDataListToClip(list2clip)
 
     def SetDataListToClip(self, data_list_to_clip):
         self.DataListToClip = {}
@@ -159,39 +160,39 @@ class cilPlaneClipper(object):
     def GetClippedData(self, key):
         return self.DataListToClip[key]
 
-    def SetInteractor(self, interactor):
-        self.Interactor = interactor
+    def SetInteractorStyle(self, interactor_style):
+        self.InteractorStyle = interactor_style
 
-    def GetInteractor(self):
-        return self.Interactor
+    def GetInteractorStyle(self):
+        return self.InteractorStyle
 
-    def UpdateClippingPlanes(self, interactor=None, event="ClipData"):
+    def UpdateClippingPlanes(self, interactor_style=None, event="ClipData"):
         try:
             if len(self.DataListToClip) > 0:
-                if interactor is None:
-                    interactor = self.Interactor
-                    interactor.UpdatePipeline()
+                if interactor_style is None:
+                    interactor_style = self.InteractorStyle
+                    interactor_style.UpdatePipeline()
 
                 normal = [0, 0, 0]
                 origin = [0, 0, 0]
                 norm = 1
 
-                orientation = interactor.GetSliceOrientation()
+                orientation = interactor_style.GetSliceOrientation()
 
-                spac = interactor.GetInputData().GetSpacing()
-                orig = interactor.GetInputData().GetOrigin()
+                spac = interactor_style.GetInputData().GetSpacing()
+                orig = interactor_style.GetInputData().GetOrigin()
                 slice_thickness = spac[orientation]
 
                 current_slice = [0, 0, 0]
-                current_slice[orientation] = interactor.getActiveSlice()
-                current_slice = interactor.image2world(current_slice)
+                current_slice[orientation] = interactor_style.GetActiveSlice()
+                current_slice = interactor_style.image2world(current_slice)
 
                 beta_up = 0.5 - 1e-9
                 beta_down = 0.5
 
                 slice_above = [0, 0, 0]
-                slice_above[orientation] = interactor.getActiveSlice() + beta_up
-                slice_above = interactor.image2world(slice_above)
+                slice_above[orientation] = interactor_style.GetActiveSlice() + beta_up
+                slice_above = interactor_style.image2world(slice_above)
 
                 normal[orientation] = norm
                 origin = slice_above
@@ -199,8 +200,8 @@ class cilPlaneClipper(object):
 
                 # update the  plane below
                 slice_below = [0, 0, 0]
-                slice_below[orientation] = interactor.getActiveSlice() - beta_down
-                slice_below = interactor.image2world(slice_below)
+                slice_below[orientation] = interactor_style.GetActiveSlice() - beta_down
+                slice_below = interactor_style.image2world(slice_below)
 
                 origin_below = [i for i in origin]
                 origin_below = slice_below
@@ -212,7 +213,7 @@ class cilPlaneClipper(object):
                     data_to_clip.SetPlaneNormalBelow((-normal[0], -normal[1], -normal[2]))
                     data_to_clip.Update()
 
-                interactor.UpdatePipeline()
+                interactor_style.UpdatePipeline()
 
         except AttributeError as ae:
             print(ae)

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -57,10 +57,6 @@ class Linked2DInteractorStyle(CIL2DInteractorStyle):
     def LinkedEventOff(self):
         self.LinkedEvent = 0
 
-    # layman solution for missing method
-    # TODO fix correctly
-    def getSliceOrientation(self):
-        return self.GetSliceOrientation()
 
 
 class ViewerLinker():

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -57,6 +57,11 @@ class Linked2DInteractorStyle(CIL2DInteractorStyle):
     def LinkedEventOff(self):
         self.LinkedEvent = 0
 
+    # layman solution for missing method
+    # TODO fix correctly
+    def getSliceOrientation(self):
+        return self.GetSliceOrientation()
+
 
 class ViewerLinker():
     """
@@ -272,7 +277,7 @@ class ViewerLinkObserver():
                     pick_position = sourceInteractorStyle.last_picked_voxel
                     targetInteractorStyle.last_picked_voxel = pick_position[:]
                     sliceno = pick_position[self.targetViewer.sliceOrientation]
-                    targetInteractorStyle.setActiveSlice(sliceno)
+                    targetInteractorStyle.SetActiveSlice(sliceno)
                     targetInteractorStyle.UpdatePipeline(True)
                     # the event has not been generated in the targetInteractor so it
                     # should not passed on to any linked interactors

--- a/Wrappers/Python/examples/FourDockableLinkedViewerWidegets.py
+++ b/Wrappers/Python/examples/FourDockableLinkedViewerWidegets.py
@@ -8,6 +8,7 @@ from ccpi.viewer import viewer2D, viewer3D
 from ccpi.viewer.QCILViewerWidget import QCILViewerWidget, QCILDockableWidget
 # Import linking class to join 2D and 3D viewers
 import ccpi.viewer.viewerLinker as vlink
+from ccpi.viewer.utils import example_data
 
 
 class FourLinkedViewersDockableWidget(QtWidgets.QMainWindow):
@@ -42,13 +43,11 @@ class FourLinkedViewersDockableWidget(QtWidgets.QMainWindow):
 
         self.viewerLinkers = viewerLinkers
 
-        if reader is None:
-            reader = vtk.vtkMetaImageReader()
-            reader.SetFileName('head.mha')
-        reader.Update()
+        head = example_data.HEAD.get()
+
 
         for el in [self.v00, self.v01, self.v10, self.v11]:
-            el.viewer.setInputData(reader.GetOutput())
+            el.viewer.setInputData(head)
         # set slice orientation
         self.v00.viewer.setSliceOrientation('x')
         self.v01.viewer.setSliceOrientation('y')

--- a/Wrappers/Python/examples/SingleViewerCentralWidget.py
+++ b/Wrappers/Python/examples/SingleViewerCentralWidget.py
@@ -3,7 +3,7 @@ import vtk
 from PySide2 import QtCore, QtWidgets
 from ccpi.viewer import viewer2D, viewer3D
 from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
-
+from ccpi.viewer.utils import example_data
 
 class SingleViewerCenterWidget(QtWidgets.QMainWindow):
 
@@ -12,12 +12,10 @@ class SingleViewerCenterWidget(QtWidgets.QMainWindow):
 
         self.frame = QCILViewerWidget(viewer=viewer, shape=(600, 600))
 
-        reader = vtk.vtkMetaImageReader()
-        reader.SetFileName('head.mha')
-        reader.Update()
+        head = example_data.HEAD.get()
 
-        self.frame.viewer.setInputData(reader.GetOutput())
-
+        self.frame.viewer.setInputData(head)
+        
         self.setCentralWidget(self.frame)
 
         self.show()

--- a/Wrappers/Python/examples/SingleViewerCentralWidget2.py
+++ b/Wrappers/Python/examples/SingleViewerCentralWidget2.py
@@ -4,6 +4,7 @@ from PySide2 import QtCore, QtWidgets
 from ccpi.viewer import viewer2D, viewer3D
 from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
 import os
+from ccpi.viewer.utils import example_data 
 
 
 class SingleViewerCenterWidget(QtWidgets.QMainWindow):
@@ -13,14 +14,10 @@ class SingleViewerCenterWidget(QtWidgets.QMainWindow):
         self.setGeometry(450, 250, 1000, 1000)
         self.frame = QCILViewerWidget(viewer=viewer, shape=(2000, 2000))
 
-        reader = vtk.vtkMetaImageReader()
-        reader.SetFileName(os.path.join("c:/Users/ofn77899/Dev/CILViewer/Wrappers/Python/examples", 'head.mha'))
-        reader.Update()
-        reader2 = vtk.vtkMetaImageReader()
-        reader2.SetFileName(os.path.join("c:/Users/ofn77899/Dev/CILViewer/Wrappers/Python/examples", 'head_root.mha'))
-        reader2.Update()
-        self.frame.viewer.setInputData(reader2.GetOutput())
-        self.frame.viewer.setInputData2(reader.GetOutput())
+        head = example_data.HEAD.get()
+
+        self.frame.viewer.setInputData(head)
+        self.frame.viewer.setInputData2(head)
 
         self.setCentralWidget(self.frame)
 

--- a/Wrappers/Python/examples/TwoLinkedViewersCentralWidget.py
+++ b/Wrappers/Python/examples/TwoLinkedViewersCentralWidget.py
@@ -7,26 +7,7 @@ from ccpi.viewer import viewer2D, viewer3D
 from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
 # Import linking class to join 2D and 3D viewers
 import ccpi.viewer.viewerLinker as vlink
-
-
-class SingleViewerCenterWidget(QtWidgets.QMainWindow):
-
-    def __init__(self, parent=None):
-        QtWidgets.QMainWindow.__init__(self, parent)
-        #self.resize(800,600)
-
-        self.frame = QCILViewerWidget(viewer=viewer3D, shape=(600, 600))
-
-        reader = vtk.vtkMetaImageReader()
-        reader.SetFileName('head.mha')
-        reader.Update()
-
-        self.frame.viewer.setInputData(reader.GetOutput())
-
-        self.setCentralWidget(self.frame)
-
-        self.show()
-
+from ccpi.viewer.utils import example_data
 
 class TwoLinkedViewersCenterWidget(QtWidgets.QMainWindow):
 
@@ -37,12 +18,10 @@ class TwoLinkedViewersCenterWidget(QtWidgets.QMainWindow):
         self.frame1 = QCILViewerWidget(viewer=viewer2D, shape=(600, 600), interactorStyle=vlink.Linked2DInteractorStyle)
         self.frame2 = QCILViewerWidget(viewer=viewer3D, shape=(600, 600), interactorStyle=vlink.Linked3DInteractorStyle)
 
-        reader = vtk.vtkMetaImageReader()
-        reader.SetFileName('head.mha')
-        reader.Update()
+        head = example_data.HEAD.get()
 
-        self.frame1.viewer.setInputData(reader.GetOutput())
-        self.frame2.viewer.setInputData(reader.GetOutput())
+        self.frame1.viewer.setInputData(head)
+        self.frame2.viewer.setInputData(head)
 
         # Initially link viewers
         self.linkedViewersSetup()


### PR DESCRIPTION
Uses `example_data` to load a dataset in the examples.

I think that example data could return a reader rather than a `vtkImageData`, what do you think?