### PR TITLE
Fix build variants so that we get different versions for each python + VTK combination

### DIFF
--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -26,4 +26,6 @@ jobs:
         publish: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
         test_all: ${{(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')) || (github.ref == 'refs/heads/master')}}
         additional_apt_packages: 'libegl1-mesa libegl1-mesa-dev'
+        convert_win: 'true'
+        convert_osx: 'true'
 

--- a/Wrappers/Python/conda-recipe/conda_build_config.yaml
+++ b/Wrappers/Python/conda-recipe/conda_build_config.yaml
@@ -10,7 +10,6 @@ vtk:
   - 9.*
   - 9.*
   - 9.*
-
 zip_keys:
   - python
   - vtk

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -9,7 +9,6 @@ build:
   skip: True # [py==38 and np==115]
   preserve_egg_dir: False 
   number: {{ GIT_DESCRIBE_NUMBER }}
-  # noarch: generic
   entry_points:
     - web_cilviewer = ccpi.web_viewer.web_app:main
   

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ build:
   skip: True # [py==38 and np==115]
   preserve_egg_dir: False 
   number: {{ GIT_DESCRIBE_NUMBER }}
-  noarch: python
+  # noarch: generic
   entry_points:
     - web_cilviewer = ccpi.web_viewer.web_app:main
   
@@ -26,13 +26,13 @@ test:
   
 requirements:
   build:
-    - python {{ python }}
+    - python
     - vtk {{ vtk }}
  
   run:
-    - python {{ python }}
+    - python
     - numpy
-    - vtk {{ vtk }}
+    - {{ pin_compatible('vtk', min_pin='x.x', max_pin='x.x') }}
     - pyside2
     - eqt
     - importlib_metadata    # [py<38]


### PR DESCRIPTION
Previously the variants were not being built as we had the setting:

`noarch: python`