### PR TITLE
enable bind directory on host

### DIFF
--- a/docker/web-app/Dockerfile
+++ b/docker/web-app/Dockerfile
@@ -43,4 +43,7 @@ RUN rm create-data-folder.sh
 
 COPY entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# set default parameter for entrypoint
+#https://docs.docker.com/engine/reference/builder/#cmd
+CMD ["/home/abc/data"]
 

--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -8,3 +8,7 @@ Using the most recently created docker image as the image ID:
 `docker run -p 8080:8080 <image-id>`
 
 The container should start with a web server running an individual client's CILViewer instance on 0.0.0.0:8080, and the listed docker IP address in the attached console.
+
+To bind a directory with data on the host one could launch
+
+`docker run -p 8080:8080 --mount type=bind,source="$(pwd)"/volume,target=/home/abc/bind <image-id> /home/abc/bind`

--- a/docker/web-app/entrypoint.sh
+++ b/docker/web-app/entrypoint.sh
@@ -3,4 +3,4 @@
 . /home/abc/mambaforge/etc/profile.d/conda.sh
 conda activate cilviewer_webapp
 
-xvfb-run -a web_cilviewer ./data --host 0.0.0.0 --server
+xvfb-run -a web_cilviewer $1 --host 0.0.0.0 --server


### PR DESCRIPTION
Enables binding a directory between the host and the container. This to avoid copying data to the container.

closes #306