### PR TITLE
Get spacing and origin from original tiff file and use when downsampling

### DIFF
--- a/Wrappers/Python/ccpi/viewer/utils/conversion.py
+++ b/Wrappers/Python/ccpi/viewer/utils/conversion.py
@@ -1126,6 +1126,9 @@ class cilTIFFImageReaderInterface(cilReaderInterface):
 
         self.SetOutputVTKType(reader.GetOutput().GetScalarType())
 
+        self.SetElementSpacing(reader.GetOutput().GetSpacing())
+        self.SetOrigin(reader.GetOutput().GetOrigin())
+
         self.Modified()
 
 


### PR DESCRIPTION
Fixes #310 