### PR TITLE
Add schema to env file

### DIFF
--- a/Wrappers/Python/conda-recipe/environment.yml
+++ b/Wrappers/Python/conda-recipe/environment.yml
@@ -13,3 +13,4 @@ dependencies:
     - h5py
     - cil-data >=22.0.0
     - pillow
+    - schema


### PR DESCRIPTION
As seen in the conda recipe: https://github.com/vais-ral/CILViewer/blob/d241c48b03ad6f9c7e5835cd7c6a7537c25811dc/Wrappers/Python/conda-recipe/meta.yaml#L41, this is a requirement for the module