### PR TITLE
Convert HDF5 attributes to a dict before returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vx.x.x
 - add `deleteWidget` method to CILViewerBase
 - Add environment file for development of the viewer
+- Fix bug with returning HDF5 attributes from HDF5Reader
 
 ## v22.4.0
 - Add command line tool for resampling a dataset, with entrypoint: resample (and unit tests)

--- a/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
+++ b/Wrappers/Python/ccpi/viewer/utils/hdf5_io.py
@@ -150,7 +150,7 @@ class HDF5Reader(VTKPythonAlgorithmBase):
         with h5py.File(self._FileName, 'r') as f:
             if self._DatasetName is None:
                 raise Exception("DataSetName must be set.")
-            return f[self._DatasetName].attrs
+            return dict(f[self._DatasetName].attrs)
 
     def GetOrigin(self):
         # There is not a standard way to set the origin in a HDF5


### PR DESCRIPTION
What happens at the moment is that the attributes are returned and then the file is closed. This then means the attributes aren't accessible: if I try to read the attributes, they are returned as type: `<Attributes of closed HDF5 object>`, and then if I try to print the keys I get an error:

> ValueError: Invalid dataset identifier (invalid dataset identifier)

Changing to return the attributes as a dict resolves this issue and allows me to access the attributes items