### PR TITLE
Fix dependency versions

### DIFF
--- a/Wrappers/Python/conda-recipe/environment.yml
+++ b/Wrappers/Python/conda-recipe/environment.yml
@@ -2,7 +2,7 @@ name: cilviewer_dev
 channels:
   - ccpi
   - conda-forge
-dependencies:
+dependencies: 
     - python
     - numpy
     - vtk=9.0.3

--- a/Wrappers/Python/conda-recipe/environment.yml
+++ b/Wrappers/Python/conda-recipe/environment.yml
@@ -5,11 +5,11 @@ channels:
 dependencies:
     - python
     - numpy
-    - vtk >=9.0.3
+    - vtk=9.0.3
     - pyside2
-    - eqt>=0.7.0
+    - eqt=0.7.1
     - importlib_metadata    # [py<38]
     - h5py
-    - cil-data >=22.0.0
+    - cil-data=22.0.0
     - pillow
     - schema

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -35,12 +35,12 @@ requirements:
     - numpy
     - vtk {{ vtk }}
     - pyside2
-    - eqt>=0.7.0
+    - eqt=0.7.0
     - importlib_metadata    # [py<38]
     - h5py
     - schema
     - pyyaml
-    - cil-data >=22.0.0
+    - cil-data =22.0.0
 
 about:
   home: http://www.ccpi.ac.uk

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - numpy
     - vtk {{ vtk }}
     - pyside2
-    - eqt=0.7.0
+    - eqt=0.7.1
     - importlib_metadata    # [py<38]
     - h5py
     - schema


### PR DESCRIPTION
Set dependency versions to be fixed.
This is especially important because later releases of eqt will break backwards incompatability