### PR TITLE
Remove qapplication from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## vx.x.x
+- Fix failing unit test #394
 - Add slider widget #365
 - Removed VTK 8 variants from conda recipe.
 - Change Python variants: removed 3.6 and 3.7, added 3.11 and 3.12.

--- a/Wrappers/Python/test/test_viewer_main_windows.py
+++ b/Wrappers/Python/test/test_viewer_main_windows.py
@@ -17,8 +17,6 @@ else:
 
 print("skip_as_conda_build is set to ", skip_as_conda_build)
 
-_instance = None
-
 
 @unittest.skipIf(skip_as_conda_build, "On conda builds do not do any test with interfaces")
 class TestViewerMainWindow(unittest.TestCase):
@@ -37,10 +35,6 @@ class TestViewerMainWindow(unittest.TestCase):
         pass
 
     def test_all(self):
-        global _instance
-        if _instance is None:
-            _instance = QApplication(sys.argv)
-
         # https://stackoverflow.com/questions/5387299/python-unittest-testcase-execution-order
         # https://stackoverflow.com/questions/11145583/unit-and-functional-testing-a-pyside-based-application
         self._test_init()
@@ -56,8 +50,6 @@ class TestViewerMainWindow(unittest.TestCase):
         self._test_updateViewerCoords_with_display_downsampled_coords_selected()
         self._test_updateViewerCoords_with_3D_viewer()
         self._test_updateViewerCoords_with_no_img3D()
-
-        del _instance
 
     def _test_init(self):
         vmw = ViewerMainWindow(title="Testing Title", app_name="testing app name")


### PR DESCRIPTION
## Describe your changes
removed the qapplication instance from the test

## Describe any testing you have performed
*Consider adding example code to [examples](https://github.com/vais-ral/CILViewer/tree/pr-template/Wrappers/Python/examples)*

I run the pytests before and after.
I can see a new window appearing on the screen which indicates new tests are being performed.


## Link relevant issues
Closes #367 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the [CIL developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html)
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'waiting for review' 

## Contribution Notes
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CILViewer (the Work) under the terms and conditions of the [Apache-2.0 License](https://spdx.org/licenses/Apache-2.0.html)
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

Qt contributions should follow Qt naming conventions i.e. camelCase method names.

VTK contributions should follow VTK naming conventions i.e. PascalCase method names.
