### PR TITLE
Fix path to upload in conda-publish action

### DIFF
--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -39,7 +39,6 @@ jobs:
 
 
   conda-print:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
     runs-on: ubuntu-22.04
     needs: build
     defaults: {run: {shell: 'bash -el {0}', working-directory: dist}}

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -37,6 +37,30 @@ jobs:
           name: cilviewer
           path: dist
 
+
+  conda-print:
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
+    runs-on: ubuntu-22.04
+    needs: build
+    defaults: {run: {shell: 'bash -el {0}', working-directory: dist}}
+    steps:
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          mamba-version: "*"
+          channels: conda-forge
+
+      - name: Download built conda package
+        uses: actions/download-artifact@v4
+        with:
+          name: cilviewer
+          path: dist
+
+      - run: conda install anaconda-client
+
+      - name: print contents of dist folder
+        run: >
+          ls dist
+
   conda-upload:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
     runs-on: ubuntu-22.04

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: print contents of dist folder
         run: >
-          ls dist
+          ls .
 
   conda-upload:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: print contents of dist folder
         run: >
-          ls .
+          ls noarch
 
   conda-upload:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'

--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -37,29 +37,6 @@ jobs:
           name: cilviewer
           path: dist
 
-
-  conda-print:
-    runs-on: ubuntu-22.04
-    needs: build
-    defaults: {run: {shell: 'bash -el {0}', working-directory: dist}}
-    steps:
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          mamba-version: "*"
-          channels: conda-forge
-
-      - name: Download built conda package
-        uses: actions/download-artifact@v4
-        with:
-          name: cilviewer
-          path: dist
-
-      - run: conda install anaconda-client
-
-      - name: print contents of dist folder
-        run: >
-          ls noarch
-
   conda-upload:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
     runs-on: ubuntu-22.04
@@ -81,4 +58,4 @@ jobs:
 
       - name: Upload to ccpi anaconda channel
         run: >
-          anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload --force --label 'main' dist/noarch/*
+          anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload --force --label 'main' noarch/*


### PR DESCRIPTION
Added a new job 'conda-print' to print contents of the dist folder after building the conda package.

## Describe your changes


## Describe any testing you have performed
*Consider adding example code to [examples](https://github.com/vais-ral/CILViewer/tree/pr-template/Wrappers/Python/examples)*
Added conda-print job to CI workflow and from that I learnt that the path should just be noarch, not dist.

## Link relevant issues


## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the [CIL developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html)
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'waiting for review' 

## Contribution Notes
- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CILViewer (the Work) under the terms and conditions of the [Apache-2.0 License](https://spdx.org/licenses/Apache-2.0.html)
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

Qt contributions should follow Qt naming conventions i.e. camelCase method names.

VTK contributions should follow VTK naming conventions i.e. PascalCase method names.
